### PR TITLE
Add re-centre according to marker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "terraink",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/poster/ui/PreviewPanel.tsx
+++ b/src/features/poster/ui/PreviewPanel.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type CSSProperties,
@@ -9,6 +10,7 @@ import { usePosterContext } from "./PosterContext";
 import { useMapSync } from "@/features/map/application/useMapSync";
 import MapPreview from "@/features/map/ui/MapPreview";
 import MarkerOverlay from "@/features/markers/ui/MarkerOverlay";
+import MarkerVisual from "@/features/markers/ui/MarkerVisual";
 import GradientFades from "./GradientFades";
 import PosterTextOverlay from "./PosterTextOverlay";
 import {
@@ -21,6 +23,7 @@ import {
   RotateRightIcon,
   LockIcon,
   RecenterIcon,
+  ChevronDownIcon,
 } from "@/shared/ui/Icons";
 import {
   MAP_BUTTON_ZOOM_DURATION_MS,
@@ -37,6 +40,7 @@ import {
   DEFAULT_COUNTRY,
 } from "@/core/config";
 import { ensureGoogleFont, reverseGeocodeCoordinates } from "@/core/services";
+import { findMarkerIcon } from "@/features/markers/infrastructure/iconRegistry";
 
 const LOCKED_HINT = "Map is locked to prevent unintended movement.";
 const EDIT_HINT_ACTIVE =
@@ -46,6 +50,15 @@ const COUNTRY_VIEW_ZOOM_LEVEL = 10;
 const CONTINENT_VIEW_ZOOM_LEVEL = 6;
 const DEFAULT_LOCATION_LABEL =
   "Hanover, Region Hannover, Lower Saxony, Germany";
+
+interface RecenterMarkerTarget {
+  id: string;
+  name: string;
+  lat: number;
+  lon: number;
+  color: string;
+  iconId: string;
+}
 
 export default function PreviewPanel() {
   const { state, dispatch, effectiveTheme, mapStyle, mapRef } = usePosterContext();
@@ -63,9 +76,24 @@ export default function PreviewPanel() {
   } = useMapSync();
 
   const frameRef = useRef<HTMLDivElement | null>(null);
+  const recenterControlRef = useRef<HTMLDivElement | null>(null);
   const [isEditing, setIsEditing] = useState(false);
   const [mapBearing, setMapBearing] = useState(0);
   const [isRotationEnabled, setIsRotationEnabled] = useState(false);
+  const [isRecenterMenuOpen, setIsRecenterMenuOpen] = useState(false);
+
+  const markerTargets = useMemo<RecenterMarkerTarget[]>(
+    () =>
+      state.markers.map((marker, index) => ({
+        id: marker.id,
+        name: `Marker ${index + 1}`,
+        lat: marker.lat,
+        lon: marker.lon,
+        color: marker.color,
+        iconId: marker.iconId,
+      })),
+    [state.markers],
+  );
 
   useEffect(() => {
     const element = frameRef.current;
@@ -110,6 +138,43 @@ export default function PreviewPanel() {
     setIsRotationEnabled(false);
   }, [isMarkerEditorActive]);
 
+  useEffect(() => {
+    if (markerTargets.length > 0) {
+      return;
+    }
+    setIsRecenterMenuOpen(false);
+  }, [markerTargets.length]);
+
+  useEffect(() => {
+    setIsRecenterMenuOpen(false);
+  }, [isEditing, isMarkerEditorActive]);
+
+  useEffect(() => {
+    if (!isRecenterMenuOpen) return;
+
+    const handlePointerDown = (event: MouseEvent | TouchEvent) => {
+      const targetNode = event.target;
+      if (!(targetNode instanceof Node)) return;
+      if (recenterControlRef.current?.contains(targetNode)) return;
+      setIsRecenterMenuOpen(false);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      setIsRecenterMenuOpen(false);
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("touchstart", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("touchstart", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isRecenterMenuOpen]);
+
   const widthCm = Number(form.width) || DEFAULT_POSTER_WIDTH_CM;
   const heightCm = Number(form.height) || DEFAULT_POSTER_HEIGHT_CM;
   const aspect = widthCm / heightCm;
@@ -129,6 +194,7 @@ export default function PreviewPanel() {
     : isCountryContinentView
       ? form.displayContinent || "Europe"
       : "Earth";
+
 
   const handleStartEditing = useCallback(() => {
     setIsEditing(true);
@@ -286,6 +352,82 @@ export default function PreviewPanel() {
     dispatch,
   ]);
 
+  const toggleRecenterMenu = useCallback(() => {
+    if (markerTargets.length === 0) return;
+    setIsRecenterMenuOpen((current) => !current);
+  }, [markerTargets.length]);
+
+  const handleRecenterToMarker = useCallback(
+    (marker: RecenterMarkerTarget) => {
+      const map = mapRef.current;
+      if (!map) return;
+      map.easeTo({
+        center: [marker.lon, marker.lat],
+        duration: MAP_BUTTON_ZOOM_DURATION_MS,
+      });
+      setIsRecenterMenuOpen(false);
+    },
+    [mapRef],
+  );
+
+  const renderRecenterSplitButton = () => (
+    <div
+      className="map-control-split"
+      ref={recenterControlRef}
+    >
+      <button
+        type="button"
+        className="map-control-btn map-control-btn--split-main"
+        onClick={handleRecenter}
+        title={RECENTER_HINT}
+      >
+        <RecenterIcon />
+        <span>Recenter</span>
+      </button>
+      <button
+        type="button"
+        className="map-control-btn map-control-btn--split-toggle"
+        onClick={toggleRecenterMenu}
+        aria-haspopup="menu"
+        aria-expanded={isRecenterMenuOpen}
+        aria-label="Show marker recenter options"
+        disabled={markerTargets.length === 0}
+      >
+        <ChevronDownIcon />
+      </button>
+      {isRecenterMenuOpen ? (
+        <div className="map-control-dropdown" role="menu" aria-label="Marker recenter options">
+          {markerTargets.map((marker) => {
+            const markerIcon = findMarkerIcon(marker.iconId, state.customMarkerIcons);
+            return (
+              <button
+                key={marker.id}
+                type="button"
+                className="map-control-dropdown-item"
+                role="menuitem"
+                onClick={() => handleRecenterToMarker(marker)}
+              >
+                {markerIcon ? (
+                  <MarkerVisual
+                    icon={markerIcon}
+                    size={16}
+                    color={marker.color}
+                    className="map-control-dropdown-item-icon"
+                  />
+                ) : (
+                  <span className="map-control-dropdown-item-icon map-control-dropdown-item-icon--fallback" aria-hidden="true">
+                    <RecenterIcon />
+                  </span>
+                )}
+                <span>{marker.name}</span>
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+
   const handleMarkerPositionChange = useCallback(
     (markerId: string, lat: number, lon: number) => {
       dispatch({
@@ -353,15 +495,7 @@ export default function PreviewPanel() {
           {!isEditing ? (
             <>
               <div className="map-control-group">
-                <button
-                  type="button"
-                  className="map-control-btn"
-                  onClick={handleRecenter}
-                  title={RECENTER_HINT}
-                >
-                  <RecenterIcon />
-                  <span>Recenter</span>
-                </button>
+                {renderRecenterSplitButton()}
                 <button
                   type="button"
                   className="map-control-btn map-control-btn--primary"
@@ -387,15 +521,7 @@ export default function PreviewPanel() {
           ) : (
             <>
               <div className="map-control-group">
-                <button
-                  type="button"
-                  className="map-control-btn"
-                  onClick={handleRecenter}
-                  title={RECENTER_HINT}
-                >
-                  <RecenterIcon />
-                  <span>Recenter</span>
-                </button>
+                {renderRecenterSplitButton()}
                 <button
                   type="button"
                   className="map-control-btn map-control-btn--primary"

--- a/src/shared/ui/Icons.tsx
+++ b/src/shared/ui/Icons.tsx
@@ -24,3 +24,4 @@ export { FiRotateCw as RotateIcon } from "react-icons/fi";
 export { FiRotateCcw as RotateLeftIcon } from "react-icons/fi";
 export { FiRotateCw as RotateRightIcon } from "react-icons/fi";
 export { MdMyLocation as MyLocationIcon } from "react-icons/md";
+export { FaChevronDown as ChevronDownIcon } from "react-icons/fa6";

--- a/src/styles/preview.css
+++ b/src/styles/preview.css
@@ -272,6 +272,74 @@
   border: 1px solid rgba(137, 176, 200, 0.35);
 }
 
+
+.map-control-split {
+  position: relative;
+  display: inline-flex;
+  align-items: stretch;
+}
+
+.map-control-btn--split-main {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.map-control-btn--split-toggle {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  padding-inline: 9px;
+  min-width: 34px;
+}
+
+.map-control-dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  min-width: 180px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px;
+  border-radius: 10px;
+  border: 1px solid rgba(137, 176, 200, 0.42);
+  background: rgba(11, 26, 38, 0.96);
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.32);
+  z-index: 20;
+}
+
+.map-control-dropdown-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 8px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: #d5e7f5;
+  font-family: "Spline Sans Mono", monospace;
+  font-size: 0.75rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.map-control-dropdown-item:hover,
+.map-control-dropdown-item:focus-visible {
+  background: rgba(55, 171, 203, 0.2);
+  outline: none;
+}
+
+.map-control-dropdown-item-icon {
+  flex-shrink: 0;
+}
+
+.map-control-dropdown-item-icon--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+}
 .map-control-btn {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- **What does this PR change?**  
  This PR reworks the map recenter control into a split-button in `PreviewPanel`:

  - Main action keeps existing recenter behavior.
  - Dropdown toggle exposes marker-specific targets (`Marker 1`, `Marker 2`, etc.) with marker icon + color, and selecting one recenters via `map.easeTo`.
  - The split control is present in both locked and edit control rows for consistent UX.
  - Dropdown lifecycle handling was added (outside click, `Escape`, close when no markers, close on mode transitions).
  - Styling was added for split-button/dropdown UI, and `ChevronDownIcon` was exported.
  - Version bumped from `0.3.0` to `0.3.1`.

- **Why is this change needed?**  
  It preserves the existing quick recenter workflow while adding a faster, direct way to center on any placed marker, improving usability for multi-marker layouts and avoiding inconsistent behavior between locked/edit modes.

---

## Branch

- ☑ I have read the contributing guidelines  
- ☑
<img width="1440" height="1634" alt="recenter-split-dropdown" src="https://github.com/user-attachments/assets/2d42a535-7b7c-4ce9-b787-2bd6f7c2f640" />
 This branch was created from `dev` and this PR targets `dev`

---

## Implementation

- ☑ The implementation matches the requested behavior and UX  
- ☑ I followed the project architecture and reviewed any AI-assisted code before submitting  
- ☑ I avoided hard-coded values where constants, configuration, or reusable abstractions are more appropriate  

---

## Validation

- ☐ I ran `bun install` and `bun run build`  
- ☑ I tested the change locally  

---

## UI Changes

- ☐ No UI changes  
- ☑ UI screenshots or demo attached  

---

## Notes

- `npm run build` succeeded.  
- `npm run typecheck` fails due to pre-existing TypeScript issues unrelated to this PR.  
- A robustness fix was included: dropdown items now render with a fallback icon if a marker icon definition is missing (prevents items from silently disappearing).