### PR TITLE
fix: update nginx base image to resolve 45 CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN bun install --frozen-lockfile
 COPY . .
 RUN bun run build
 
-FROM nginx:1.27-alpine AS runtime
+FROM nginx:1.29-alpine AS runtime
+RUN apk upgrade --no-cache
 WORKDIR /usr/share/nginx/html
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
## Summary

- Bump runtime base image from `nginx:1.27-alpine` to `nginx:1.29-alpine`
- Add `apk upgrade --no-cache` to ensure all available Alpine patches are applied at build time

## CVE Impact

A Docker Scout scan of the current image found **56 vulnerabilities** (3C, 14H, 31M, 8L) across 10 packages — all from the outdated `nginx:1.27-alpine` base image.

This change **resolves 45 of 56 CVEs**:

| Severity | Before | After | Resolved |
|----------|--------|-------|----------|
| Critical | 3 | 0 | 3 (libxml2, openssl) |
| High | 14 | 1 | 13 (libxml2, openssl, libpng, curl, expat) |
| Medium | 31 | 9 | 22 |
| Low | 8 | 1 | 7 |
| **Total** | **56** | **11** | **45** |

The 11 remaining CVEs are **upstream-blocked** (no fix available from Alpine) in `curl` and `busybox`. These will resolve automatically on the next rebuild once Alpine ships patches.

## Test plan

- [x] `docker build` succeeds with new base image
- [x] Docker Scout scan confirms 45 CVE reduction
- [ ] Verify the app serves correctly on `localhost:7200` via `docker compose up`

🤖 Generated with [Claude Code](https://claude.com/claude-code)