### PR TITLE
feat: Nudge marker latlon with keyboard arrows

### DIFF
--- a/src/features/markers/ui/MarkerOverlay.tsx
+++ b/src/features/markers/ui/MarkerOverlay.tsx
@@ -51,6 +51,7 @@ export default function MarkerOverlay({
   onMarkerPositionChange,
   onMarkerSizeChange,
 }: MarkerOverlayProps) {
+  const KEYBOARD_MOVE_STEP = 1;
   const KEYBOARD_RESIZE_STEP = 3;
   const [, setRenderTick] = useState(0);
   const overlayRef = useRef<HTMLDivElement | null>(null);
@@ -69,6 +70,19 @@ export default function MarkerOverlay({
 
   type TouchPointLike = { clientX: number; clientY: number };
   type TouchListLike = { length: number; [index: number]: TouchPointLike };
+  const isEditableTarget = (target: EventTarget | null): boolean => {
+    if (!(target instanceof HTMLElement)) {
+      return false;
+    }
+
+    const tagName = target.tagName;
+    return (
+      target.isContentEditable ||
+      tagName === "INPUT" ||
+      tagName === "TEXTAREA" ||
+      tagName === "SELECT"
+    );
+  };
   const isMobileTouchInput = (): boolean =>
     typeof window !== "undefined" &&
     window.matchMedia("(hover: none) and (pointer: coarse)").matches;
@@ -132,6 +146,48 @@ export default function MarkerOverlay({
       }
     },
     [isMarkerEditMode, mapRef, onMarkerPositionChange],
+  );
+
+  const nudgeMarkerByScreenDelta = useCallback(
+    (markerId: string, deltaX: number, deltaY: number) => {
+      if (!isMarkerEditMode || !onMarkerPositionChange) {
+        return;
+      }
+
+      const map = mapRef.current;
+      const overlay = overlayRef.current;
+      const marker = markers.find((item) => item.id === markerId);
+      if (!map || !overlay || !marker) {
+        return;
+      }
+
+      const bounds = overlay.getBoundingClientRect();
+      if (bounds.width <= 0 || bounds.height <= 0) {
+        return;
+      }
+
+      try {
+        const currentPoint = map.project([marker.lon, marker.lat]);
+        const overlayX = clamp(
+          currentPoint.x / MAP_OVERZOOM_SCALE + deltaX,
+          0,
+          bounds.width,
+        );
+        const overlayY = clamp(
+          currentPoint.y / MAP_OVERZOOM_SCALE + deltaY,
+          0,
+          bounds.height,
+        );
+        const nextPosition = map.unproject([
+          overlayX * MAP_OVERZOOM_SCALE,
+          overlayY * MAP_OVERZOOM_SCALE,
+        ]);
+        onMarkerPositionChange(markerId, nextPosition.lat, nextPosition.lng);
+      } catch {
+        // Ignore projection failures during keyboard nudging.
+      }
+    },
+    [isMarkerEditMode, mapRef, markers, onMarkerPositionChange],
   );
 
   const handleMarkerPointerDown = useCallback(
@@ -401,18 +457,54 @@ export default function MarkerOverlay({
   }, [isMarkerEditMode, isTouchSelectionActive, selectedMarkerId]);
 
   useEffect(() => {
-    if (!isMarkerEditMode || !selectedMarkerId || !onMarkerSizeChange) {
+    if (!isMarkerEditMode || !selectedMarkerId) {
       return;
     }
 
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.defaultPrevented ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.altKey ||
+        isEditableTarget(event.target)
+      ) {
+        return;
+      }
+
+      const marker = markers.find((item) => item.id === selectedMarkerId);
+      if (!marker) {
+        return;
+      }
+
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        nudgeMarkerByScreenDelta(marker.id, 0, -KEYBOARD_MOVE_STEP);
+        return;
+      }
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        nudgeMarkerByScreenDelta(marker.id, 0, KEYBOARD_MOVE_STEP);
+        return;
+      }
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        nudgeMarkerByScreenDelta(marker.id, -KEYBOARD_MOVE_STEP, 0);
+        return;
+      }
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        nudgeMarkerByScreenDelta(marker.id, KEYBOARD_MOVE_STEP, 0);
+        return;
+      }
+
+      if (!onMarkerSizeChange) {
+        return;
+      }
+
       const isPlus = event.key === "+" || event.key === "=";
       const isMinus = event.key === "-" || event.key === "_";
       if (!isPlus && !isMinus) {
-        return;
-      }
-      const marker = markers.find((item) => item.id === selectedMarkerId);
-      if (!marker) {
         return;
       }
       event.preventDefault();
@@ -431,7 +523,13 @@ export default function MarkerOverlay({
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isMarkerEditMode, markers, onMarkerSizeChange, selectedMarkerId]);
+  }, [
+    isMarkerEditMode,
+    markers,
+    nudgeMarkerByScreenDelta,
+    onMarkerSizeChange,
+    selectedMarkerId,
+  ]);
 
   useEffect(() => {
     const map = mapRef.current;

--- a/src/features/markers/ui/MarkersSection.tsx
+++ b/src/features/markers/ui/MarkersSection.tsx
@@ -355,7 +355,7 @@ export default function MarkersSection() {
       : null;
   const markerHelpText = isMobileViewport
     ? "Click an icon to drop a marker on the current map location. Marker settings apply to all markers and can be moved directly on the map. In marker edit mode, drag to move markers and use the marker size slider below the location row to resize."
-    : "Click an icon to drop a marker on the current map location. Marker settings apply to all markers and can be moved directly on the map. In marker edit mode, drag to move, use two-finger pinch or mouse wheel to resize, and use scroll or the +/- map controls to zoom.";
+    : "Click an icon to drop a marker on the current map location. Marker settings apply to all markers and can be moved directly on the map. In marker edit mode, drag to move, use the arrow keys for fine nudging, use two-finger pinch or mouse wheel to resize, and use scroll or the +/- map controls to zoom.";
 
   return (
     <section className="panel-block color-editor-screen marker-settings-screen">
@@ -824,7 +824,7 @@ export default function MarkersSection() {
                   <p className="marker-settings-toggle-hint marker-settings-toggle-hint--editor">
                     {isMobileViewport
                       ? "Swipe the marker row to choose one, then tap it to edit. Drag it on the map to move it, and use the marker-size slider below the location row to resize."
-                      : "Click a marker card to edit it. Drag the selected marker on the map to move it, then adjust size and color in the editor."}
+                      : "Click a marker card to edit it. Drag the selected marker on the map to move it, use the arrow keys for fine nudging, then adjust size and color in the editor."}
                   </p>
                 ) : null}
 


### PR DESCRIPTION
## Summary

- Adds fine marker positioning in marker edit mode using the keyboard arrow keys
- This makes marker placement more precise than drag-only adjustment and improves the editing workflow for small visual tweaks

## Branch

- [x] I have read the [contributing guidelines](./CONTRIBUTING.md)
- [x] This branch was created from `dev` and this PR targets `dev`

## Implementation

- [x] The implementation matches the requested behavior and UX
- [x] I followed the project architecture and reviewed any AI-assisted code before submitting
- [x] I avoided hard-coded values where constants, configuration, or reusable abstractions are more appropriate

## Validation

- [x] I ran `bun install` and `bun run build`
- [x] I tested the change locally

## UI Changes

- [ ] No UI changes
- [x] UI screenshots or [demo attached](https://github.com/user-attachments/assets/77fd070d-fe9d-4e1d-95c6-42e6a5f94fc6)

## Notes

- Selected markers can now be nudged with the arrow keys while marker edit mode is active
- Existing keyboard resizing with `+` and `-` remains in place
- The keyboard handler ignores input, textarea, select, and contenteditable targets so it does not interfere with typing in form fields
- Local build validation was completed with `npm install` and `npm run build` because Bun was not installed in the local environment
- A screen recording is attached for the updated marker editing behavior
