### PR TITLE
fix(markers): decouple markers from overlay toggle

### DIFF
--- a/src/features/export/application/useExport.ts
+++ b/src/features/export/application/useExport.ts
@@ -60,7 +60,7 @@ export function useExport() {
     null,
   );
   const { form } = state;
-  const hasVisibleMarkers = form.showMarkers && state.markers.length > 0;
+  const hasVisibleMarkers = state.markers.length > 0;
 
   const registerSuccessfulExport = useCallback(() => {
     const nextCount = readPosterExportCount() + 1;

--- a/src/features/poster/ui/PreviewPanel.tsx
+++ b/src/features/poster/ui/PreviewPanel.tsx
@@ -58,7 +58,7 @@ export default function PreviewPanel() {
     isMarkerEditorActive,
     activeMarkerId,
   } = state;
-  const hasVisibleMarkers = form.showMarkers && state.markers.length > 0;
+  const hasVisibleMarkers = state.markers.length > 0;
   const {
     mapCenter,
     mapZoom,


### PR DESCRIPTION
## Summary

Markers are now always visible when present, regardless of the Overlay layer toggle. The toggle only affects gradient fades in the background.
We could also have two toggles (show/hide overlay, show/hide markers), but to me it just doesn't make sense that the overlay toggle also hides markers which are easily managed via the Markers tab.

## Branch

- [x] I have read the [contributing guidelines](./CONTRIBUTING.md)
- [x] This branch was created from `dev` and this PR targets `dev`

## Implementation

- [x] The implementation matches the requested behavior and UX
- [X] I followed the project architecture and reviewed any AI-assisted code before submitting
- [x] I avoided hard-coded values where constants, configuration, or reusable abstractions are more appropriate

## Validation

- [x] I ran `bun install` and `bun run build`
- [x] I tested the change locally

## UI Changes

- [ ] No UI changes
- [ ] UI screenshots or demo attached
