### PR TITLE
Feature/Fix: custom font picker with font preview and fixing Bebas Neue

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -80,5 +80,5 @@ export const FONT_OPTIONS: FontOption[] = [
   { value: "Raleway", label: "Raleway" },
   { value: "Lato", label: "Lato" },
   { value: "Merriweather", label: "Merriweather" },
-  { value: "Bebas neue", label: "Bebas Neue" },
+  { value: "Bebas Neue", label: "Bebas Neue" },
 ];

--- a/src/features/poster/ui/FontPicker.tsx
+++ b/src/features/poster/ui/FontPicker.tsx
@@ -1,0 +1,81 @@
+import { useState, useRef, useEffect } from "react";
+import type { FontOption } from "@/core/config";
+
+interface FontPickerProps {
+  value: string;
+  fontOptions: FontOption[];
+  onChange: (value: string) => void;
+}
+
+export default function FontPicker({
+  value,
+  fontOptions,
+  onChange,
+}: FontPickerProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const selected = fontOptions.find((o) => o.value === value) ?? fontOptions[0];
+
+  useEffect(() => {
+    if (!open) return;
+    function handlePointerDown(e: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => document.removeEventListener("mousedown", handlePointerDown);
+  }, [open]);
+
+  function fontStyle(family: string): React.CSSProperties {
+    return {
+      fontFamily: family
+        ? `"${family}", "Space Grotesk", sans-serif`
+        : '"Space Grotesk", sans-serif',
+    };
+  }
+
+  return (
+    <div className="font-picker" ref={containerRef}>
+      <button
+        type="button"
+        className="font-picker-trigger form-control-tall"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <span style={fontStyle(selected.value)}>{selected.label}</span>
+        <span className="font-picker-arrow" aria-hidden="true">
+          {open ? "\u25B4" : "\u25BE"}
+        </span>
+      </button>
+      {open && (
+        <ul
+          className="font-picker-list"
+          role="listbox"
+          aria-label="Font options"
+        >
+          {fontOptions.map((option) => (
+            <li
+              key={option.value || "default"}
+              role="option"
+              aria-selected={option.value === value}
+              className={`font-picker-option${option.value === value ? " is-selected" : ""}`}
+              style={fontStyle(option.value)}
+              onMouseDown={() => {
+                onChange(option.value);
+                setOpen(false);
+              }}
+            >
+              {option.label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/features/poster/ui/TypographySection.tsx
+++ b/src/features/poster/ui/TypographySection.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { ensureGoogleFont } from "@/core/services";
 import type { PosterForm } from "@/features/poster/application/posterReducer";
 import type { FontOption } from "@/core/config";
+import FontPicker from "./FontPicker";
 import {
   PLACEHOLDER_EXAMPLE_CITY,
   PLACEHOLDER_EXAMPLE_COUNTRY,
@@ -82,26 +83,16 @@ export default function TypographySection({
         </div>
         <label>
           Font
-          <select
-            className="form-control-tall"
-            name="fontFamily"
+          <FontPicker
             value={form.fontFamily}
-            onChange={onChange}
-          >
-            {fontOptions.map((fontOption) => (
-              <option
-                key={fontOption.value || "default"}
-                value={fontOption.value}
-                style={{
-                  fontFamily: fontOption.value
-                    ? `"${fontOption.value}", "Space Grotesk", sans-serif`
-                    : `"Space Grotesk", sans-serif`,
-                }}
-              >
-                {fontOption.label}
-              </option>
-            ))}
-          </select>
+            fontOptions={fontOptions}
+            onChange={(val) => {
+              const syntheticEvent = {
+                target: { name: "fontFamily", value: val, type: "text" },
+              } as unknown as React.ChangeEvent<HTMLSelectElement>;
+              onChange(syntheticEvent);
+            }}
+          />
         </label>
 
       </section>

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -2751,3 +2751,84 @@ button.location-clear-btn:focus-visible {
     margin-left: 0;
   }
 }
+
+/* ── Font picker custom dropdown ── */
+
+.font-picker {
+  position: relative;
+  margin-top: 4px;
+}
+
+.font-picker-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  margin-top: 0;
+  border: 1px solid rgba(151, 183, 207, 0.26);
+  border-radius: 10px;
+  background: rgba(9, 18, 27, 0.84);
+  padding: 12px 12px;
+  color: #ebf3fa;
+  font-size: 0.9rem;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 0.16s ease,
+    box-shadow 0.16s ease;
+}
+
+.font-picker-trigger:focus-visible {
+  border-color: rgba(102, 174, 209, 0.82);
+  box-shadow: 0 0 0 3px rgba(75, 149, 186, 0.24);
+  outline: none;
+}
+
+.font-picker-trigger[aria-expanded="true"] {
+  border-color: rgba(102, 174, 209, 0.82);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.font-picker-arrow {
+  flex-shrink: 0;
+  font-size: 0.65rem;
+  color: #8ca8bc;
+  margin-left: 8px;
+}
+
+.font-picker-list {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 200;
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  background: rgba(9, 18, 27, 0.97);
+  border: 1px solid rgba(102, 174, 209, 0.82);
+  border-top: none;
+  border-bottom-left-radius: 10px;
+  border-bottom-right-radius: 10px;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.font-picker-option {
+  padding: 10px 14px;
+  font-size: 0.95rem;
+  color: #d9e7f2;
+  cursor: pointer;
+  transition: background 0.1s ease;
+}
+
+.font-picker-option:hover {
+  background: rgba(94, 174, 212, 0.12);
+  color: #ebf3fa;
+}
+
+.font-picker-option.is-selected {
+  color: #dff3ff;
+  background: rgba(94, 174, 212, 0.18);
+}


### PR DESCRIPTION
## Summary

- fix: Bebas Neue MIME error (lowercase 'n' caused Google Fonts 404), sorry for adding this to this feature PR but such a small typo
- add: FontPicker component that renders each option in its own typeface, I like this preview a lot better than just seeing font names themselves
- I tried matching the style of existing form controls

## Branch

- [x] I have read the [contributing guidelines](./CONTRIBUTING.md)
- [x] This branch was created from `dev` and this PR targets `dev`

## Implementation

- [x] The implementation matches the requested behavior and UX
- [x] I followed the project architecture and reviewed any AI-assisted code before submitting
- [x] I avoided hard-coded values where constants, configuration, or reusable abstractions are more appropriate

## Validation

- [x] I ran `bun install` and `bun run build`
- [x] I tested the change locally

## UI Changes

- [ ] No UI changes
- [x] UI screenshots or demo attached

<img width="253" height="268" alt="image" src="https://github.com/user-attachments/assets/757a1514-a8a1-4ea3-97ed-c3cc43f153c8" />
