### PR TITLE
Feature: layer color pickers

### DIFF
--- a/src/features/map/ui/LayersSection.tsx
+++ b/src/features/map/ui/LayersSection.tsx
@@ -1,24 +1,33 @@
+import { useState, useEffect, useRef } from "react";
+import type { PosterForm } from "@/features/poster/application/posterReducer";
+import type { ResolvedTheme } from "@/features/theme/domain/types";
+import type { ThemeColorKey } from "@/features/theme/domain/types";
+import { getThemeColorByPath } from "@/features/theme/domain/colorPaths";
+import ColorPicker from "@/features/theme/ui/ColorPicker";
 import MapDimensionFields from "./MapDimensionFields";
 
-interface LayerForm {
-  width: string;
-  height: string;
-  distance: string;
-  includeLandcover: boolean;
-  includeBuildings: boolean;
-  includeWater: boolean;
-  includeParks: boolean;
-  includeAeroway: boolean;
-  includeRail: boolean;
-  includeRoads: boolean;
-  includeRoadPath: boolean;
-  includeRoadMinorLow: boolean;
-  includeRoadOutline: boolean;
+interface LayerRow {
+  toggleName: keyof PosterForm;
+  label: string;
+  colorKey: ThemeColorKey;
 }
 
+const LAYER_ROWS: LayerRow[] = [
+  { toggleName: "includeBuildings", label: "Show buildings", colorKey: "map.buildings" },
+  { toggleName: "includeWater",     label: "Show water",     colorKey: "map.water"     },
+  { toggleName: "includeParks",     label: "Show parks",     colorKey: "map.parks"     },
+  { toggleName: "includeRoads",     label: "Show roads",     colorKey: "map.roads.major" },
+  { toggleName: "includeRail",      label: "Show rail",      colorKey: "map.rail"      },
+  { toggleName: "includeAeroway",   label: "Show aeroway",   colorKey: "map.aeroway"   },
+];
+
 interface LayersSectionProps {
-  form: LayerForm;
+  form: PosterForm;
+  effectiveTheme: ResolvedTheme;
+  customColors: Record<string, string>;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onColorChange: (key: ThemeColorKey, value: string) => void;
+  onResetColor: (key: ThemeColorKey) => void;
   minPosterCm: number;
   maxPosterCm: number;
   onNumericFieldBlur: (event: React.FocusEvent<HTMLInputElement>) => void;
@@ -26,13 +35,36 @@ interface LayersSectionProps {
 
 export default function LayersSection({
   form,
+  effectiveTheme,
+  customColors,
   onChange,
+  onColorChange,
+  onResetColor,
   minPosterCm,
   maxPosterCm,
   onNumericFieldBlur,
 }: LayersSectionProps) {
+  const [openKey, setOpenKey] = useState<ThemeColorKey | null>(null);
+  const sectionRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (sectionRef.current && !sectionRef.current.contains(e.target as Node)) {
+        setOpenKey(null);
+      }
+    }
+    if (openKey) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [openKey]);
+
+  const themeColors = LAYER_ROWS.map((row) =>
+    String(getThemeColorByPath(effectiveTheme, row.colorKey) ?? ""),
+  );
+
   return (
-    <section className="panel-block">
+    <section className="panel-block" ref={sectionRef}>
       <p className="section-summary-label">LAYERS</p>
       <label className="toggle-field">
         <span>Show landcover</span>
@@ -46,78 +78,51 @@ export default function LayersSection({
           <span className="theme-switch-track" aria-hidden="true" />
         </span>
       </label>
-      <label className="toggle-field">
-        <span>Show buildings</span>
-        <span className="theme-switch">
-          <input
-            type="checkbox"
-            name="includeBuildings"
-            checked={Boolean(form.includeBuildings)}
-            onChange={onChange}
-          />
-          <span className="theme-switch-track" aria-hidden="true" />
-        </span>
-      </label>
-      <label className="toggle-field">
-        <span>Show water</span>
-        <span className="theme-switch">
-          <input
-            type="checkbox"
-            name="includeWater"
-            checked={Boolean(form.includeWater)}
-            onChange={onChange}
-          />
-          <span className="theme-switch-track" aria-hidden="true" />
-        </span>
-      </label>
-      <label className="toggle-field">
-        <span>Show parks</span>
-        <span className="theme-switch">
-          <input
-            type="checkbox"
-            name="includeParks"
-            checked={Boolean(form.includeParks)}
-            onChange={onChange}
-          />
-          <span className="theme-switch-track" aria-hidden="true" />
-        </span>
-      </label>
-      <label className="toggle-field">
-        <span>Show roads</span>
-        <span className="theme-switch">
-          <input
-            type="checkbox"
-            name="includeRoads"
-            checked={Boolean(form.includeRoads)}
-            onChange={onChange}
-          />
-          <span className="theme-switch-track" aria-hidden="true" />
-        </span>
-      </label>
-      <label className="toggle-field">
-        <span>Show rail</span>
-        <span className="theme-switch">
-          <input
-            type="checkbox"
-            name="includeRail"
-            checked={Boolean(form.includeRail)}
-            onChange={onChange}
-          />
-          <span className="theme-switch-track" aria-hidden="true" />
-        </span>
-      </label>
-      <label className="toggle-field">
-        <span>Show aeroway</span>
-        <span className="theme-switch">
-          <input
-            type="checkbox"
-            name="includeAeroway"
-            checked={Boolean(form.includeAeroway)}
-            onChange={onChange}
-          />
-          <span className="theme-switch-track" aria-hidden="true" />
-        </span>
-      </label>
+
+      {LAYER_ROWS.map((row, i) => {
+        const currentColor = themeColors[i];
+        const isOpen = openKey === row.colorKey;
+        const isCustom = row.colorKey in customColors;
+
+        return (
+          <div key={row.toggleName} className="layer-row">
+            <div className="toggle-field layer-toggle-field">
+              <span>{row.label}</span>
+              <div className="layer-row-controls">
+                <button
+                  type="button"
+                  className={`layer-color-btn${isCustom ? " is-custom" : ""}`}
+                  style={{ backgroundColor: currentColor }}
+                  onClick={() => setOpenKey(isOpen ? null : row.colorKey)}
+                  title={`Change ${row.label.replace("Show ", "")} color`}
+                  aria-pressed={isOpen}
+                />
+                <span className="theme-switch">
+                  <input
+                    type="checkbox"
+                    name={row.toggleName}
+                    checked={Boolean(form[row.toggleName])}
+                    onChange={onChange}
+                  />
+                  <span className="theme-switch-track" aria-hidden="true" />
+                </span>
+              </div>
+            </div>
+
+            {isOpen && (
+              <div className="layer-color-popover">
+                <ColorPicker
+                  currentColor={currentColor}
+                  suggestedColors={themeColors}
+                  onChange={(color) => onColorChange(row.colorKey, color)}
+                  onResetColor={() => onResetColor(row.colorKey)}
+                  canResetColor={isCustom}
+                />
+              </div>
+            )}
+          </div>
+        );
+      })}
 
       <div className="map-details-section">
         <h3 className="map-details-subtitle">Map Details</h3>

--- a/src/features/map/ui/LayersSection.tsx
+++ b/src/features/map/ui/LayersSection.tsx
@@ -97,7 +97,7 @@ export default function LayersSection({
                   title={`Change ${row.label.replace("Show ", "")} color`}
                   aria-pressed={isOpen}
                 />
-                <span className="theme-switch">
+                <label className="theme-switch">
                   <input
                     type="checkbox"
                     name={row.toggleName}
@@ -105,7 +105,7 @@ export default function LayersSection({
                     onChange={onChange}
                   />
                   <span className="theme-switch-track" aria-hidden="true" />
-                </span>
+                </label>
               </div>
             </div>
 

--- a/src/features/map/ui/LayersSection.tsx
+++ b/src/features/map/ui/LayersSection.tsx
@@ -13,6 +13,7 @@ interface LayerRow {
 }
 
 const LAYER_ROWS: LayerRow[] = [
+  { toggleName: "includeLandcover", label: "Show landcover", colorKey: "map.landcover" },
   { toggleName: "includeBuildings", label: "Show buildings", colorKey: "map.buildings" },
   { toggleName: "includeWater",     label: "Show water",     colorKey: "map.water"     },
   { toggleName: "includeParks",     label: "Show parks",     colorKey: "map.parks"     },
@@ -66,18 +67,6 @@ export default function LayersSection({
   return (
     <section className="panel-block" ref={sectionRef}>
       <p className="section-summary-label">LAYERS</p>
-      <label className="toggle-field">
-        <span>Show landcover</span>
-        <span className="theme-switch">
-          <input
-            type="checkbox"
-            name="includeLandcover"
-            checked={Boolean(form.includeLandcover)}
-            onChange={onChange}
-          />
-          <span className="theme-switch-track" aria-hidden="true" />
-        </span>
-      </label>
 
       {LAYER_ROWS.map((row, i) => {
         const currentColor = themeColors[i];

--- a/src/features/poster/application/posterReducer.ts
+++ b/src/features/poster/application/posterReducer.ts
@@ -75,6 +75,7 @@ export type PosterAction =
   | { type: "SET_THEME"; themeId: string }
   | { type: "SET_LAYOUT"; layoutId: string; widthCm: string; heightCm: string }
   | { type: "SET_COLOR"; key: string; value: string }
+  | { type: "RESET_COLOR"; key: string }
   | { type: "RESET_COLORS" }
   | { type: "SELECT_LOCATION"; location: SearchResult }
   | { type: "SET_USER_LOCATION"; location: SearchResult | null }
@@ -171,6 +172,11 @@ export function posterReducer(
         ...state,
         customColors: { ...state.customColors, [action.key]: action.value },
       };
+
+    case "RESET_COLOR": {
+      const { [action.key]: _removed, ...rest } = state.customColors;
+      return { ...state, customColors: rest };
+    }
 
     case "RESET_COLORS":
       return { ...state, customColors: {} };

--- a/src/features/poster/application/useFormHandlers.ts
+++ b/src/features/poster/application/useFormHandlers.ts
@@ -146,6 +146,13 @@ export function useFormHandlers() {
     [dispatch],
   );
 
+  const handleResetColor = useCallback(
+    (key: string) => {
+      dispatch({ type: "RESET_COLOR", key });
+    },
+    [dispatch],
+  );
+
   const handleResetColors = useCallback(() => {
     dispatch({ type: "RESET_COLORS" });
   }, [dispatch]);
@@ -188,6 +195,7 @@ export function useFormHandlers() {
     handleThemeChange,
     handleLayoutChange,
     handleColorChange,
+    handleResetColor,
     handleResetColors,
     handleLocationSelect,
     handleClearLocation,

--- a/src/features/poster/ui/SettingsPanel.tsx
+++ b/src/features/poster/ui/SettingsPanel.tsx
@@ -56,13 +56,14 @@ export default function SettingsPanel({
 }: {
   mobileTab?: MobileTab;
 }) {
-  const { state, dispatch, mapRef, selectedTheme } = usePosterContext();
+  const { state, dispatch, mapRef, selectedTheme, effectiveTheme } = usePosterContext();
   const {
     handleChange,
     handleNumericFieldBlur,
     handleThemeChange,
     handleLayoutChange,
     handleColorChange,
+    handleResetColor,
     handleResetColors,
     handleLocationSelect,
     handleClearLocation,
@@ -231,7 +232,11 @@ export default function SettingsPanel({
             {!isAuxEditorActive ? (
               <LayersSection
                 form={state.form}
+                effectiveTheme={effectiveTheme}
+                customColors={state.customColors}
                 onChange={handleChange}
+                onColorChange={handleColorChange}
+                onResetColor={handleResetColor}
                 minPosterCm={MIN_POSTER_CM}
                 maxPosterCm={MAX_POSTER_CM}
                 onNumericFieldBlur={handleNumericFieldBlur}

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -274,6 +274,50 @@ label {
   margin-top: 10px;
 }
 
+/* Layer rows with inline color swatch */
+
+.layer-row {
+  margin-bottom: 10px;
+}
+
+.layer-toggle-field {
+  margin-bottom: 0;
+}
+
+.layer-row-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+button.layer-color-btn {
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  border: 2px solid rgba(214, 233, 247, 0.25);
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+  transition: border-color 0.15s ease, transform 0.1s ease;
+}
+
+button.layer-color-btn:hover,
+button.layer-color-btn:focus-visible {
+  border-color: rgba(214, 233, 247, 0.7);
+  transform: scale(1.15);
+}
+
+button.layer-color-btn.is-custom {
+  border-color: #5eaed4;
+  box-shadow: 0 0 0 2px rgba(94, 174, 212, 0.35);
+}
+
+.layer-color-popover {
+  margin-top: 6px;
+  margin-bottom: 4px;
+}
+
 .credits-hint {
   margin: 2px 0 0;
   font-size: 0.74rem;


### PR DESCRIPTION
## Summary

I like choosing a base theme using the theme tab and then do fine adjustments using the layer tab since I might want to change *just* the road color or something like that. I can do that using the Theme tab, but why not have an additional possibility to directly change the color (using existing UI) using the layers tab.

This PR adds this functionality and the colors are completely in sync with the existing theme, so it just another more direct approach to edit the color somewhere else.

## Branch

- [x] I have read the [contributing guidelines](./CONTRIBUTING.md)
- [x] This branch was created from `dev` and this PR targets `dev`

## Implementation

- [x] The implementation matches the requested behavior and UX
- [x] I followed the project architecture and reviewed any AI-assisted code before submitting
- [x] I avoided hard-coded values where constants, configuration, or reusable abstractions are more appropriate

## Validation

- [x] I ran `bun install` and `bun run build`
- [x] I tested the change locally

## UI Changes

- [ ] No UI changes
- [x] UI screenshots or demo attached

<img width="330" height="352" alt="image" src="https://github.com/user-attachments/assets/eee19d06-2275-42c3-b479-eb0bca556168" />
