### PR TITLE
✨ feat(map/export): cycle ways, country borders, boundary clipping, and vector SVG export

### DIFF
--- a/src/core/services.ts
+++ b/src/core/services.ts
@@ -18,6 +18,7 @@ const nominatim = createNominatimAdapter(fetchAdapter, localStorageCache);
 export const searchLocations = nominatim.searchLocations;
 export const geocodeLocation = nominatim.geocodeLocation;
 export const reverseGeocodeCoordinates = nominatim.reverseGeocode;
+export const fetchLocationBoundary = nominatim.fetchLocationBoundary;
 
 /* ── Fonts ── */
 

--- a/src/features/export/infrastructure/layeredSvgExporter.ts
+++ b/src/features/export/infrastructure/layeredSvgExporter.ts
@@ -16,6 +16,7 @@ import {
   createOffscreenContainer,
   resolveExportRenderParams,
 } from "./exportUtils";
+import { renderMapLayersAsSvg, type VectorMapLayer } from "./vectorMapSvg";
 
 interface LayeredSvgOptions {
   map: MaplibreMap;
@@ -72,6 +73,68 @@ function sanitizeLayerId(id: string): string {
   return id.replace(/[^a-zA-Z0-9_-]/g, "-");
 }
 
+/**
+ * Raster fallback: shows one style layer at a time and snapshots the canvas,
+ * preserving the layered structure when vector geometry is unavailable.
+ */
+async function captureMapLayersAsDataUrls(
+  exportMap: MaplibreMap,
+  exportWidth: number,
+  exportHeight: number,
+): Promise<{ id: string; dataUrl: string }[]> {
+  const layerIds = (exportMap.getStyle().layers ?? []).map((layer) => layer.id);
+  const originalVisibility = new Map<string, string>();
+  const visibleLayerIds = layerIds.filter((layerId) => {
+    const visibility = String(
+      exportMap.getLayoutProperty(layerId, "visibility") ?? "visible",
+    );
+    originalVisibility.set(layerId, visibility);
+    return visibility !== "none";
+  });
+
+  for (const layerId of visibleLayerIds) {
+    exportMap.setLayoutProperty(layerId, "visibility", "none");
+  }
+  await waitForMapIdle(exportMap);
+
+  const captured: { id: string; dataUrl: string }[] = [];
+  for (const layerId of visibleLayerIds) {
+    exportMap.setLayoutProperty(layerId, "visibility", "visible");
+    await waitForMapIdle(exportMap);
+    captured.push({
+      id: layerId,
+      dataUrl: renderMapCanvasToDataUrl(
+        exportMap.getCanvas(),
+        exportWidth,
+        exportHeight,
+      ),
+    });
+    exportMap.setLayoutProperty(layerId, "visibility", "none");
+    await waitForMapIdle(exportMap);
+  }
+
+  for (const layerId of layerIds) {
+    exportMap.setLayoutProperty(
+      layerId,
+      "visibility",
+      originalVisibility.get(layerId) ?? "visible",
+    );
+  }
+  await waitForMapIdle(exportMap);
+
+  return captured;
+}
+
+function toSvgGroups(prefix: string, layers: VectorMapLayer[]): string {
+  return layers
+    .map(
+      (layer) => `<g id="${prefix}-${sanitizeLayerId(layer.id)}">
+  ${layer.markup}
+</g>`,
+    )
+    .join("\n");
+}
+
 export async function createLayeredSvgBlobFromMap({
   map,
   exportWidth,
@@ -124,43 +187,20 @@ export async function createLayeredSvgBlobFromMap({
   try {
     await waitForMapIdle(exportMap);
 
-    const exportStyle = exportMap.getStyle();
-    const layerIds = (exportStyle.layers ?? []).map((layer) => layer.id);
-    const originalVisibility = new Map<string, string>();
-    const visibleLayerIds = layerIds.filter((layerId) => {
-      const visibility = String(
-        exportMap.getLayoutProperty(layerId, "visibility") ?? "visible",
-      );
-      originalVisibility.set(layerId, visibility);
-      return visibility !== "none";
+    const vectorMapLayers = renderMapLayersAsSvg({
+      map: exportMap,
+      exportWidth,
+      exportHeight,
+      projection: markerProjection,
+      scaleX: markerScaleX,
+      scaleY: markerScaleY,
     });
 
-    for (const layerId of visibleLayerIds) {
-      exportMap.setLayoutProperty(layerId, "visibility", "none");
-    }
-    await waitForMapIdle(exportMap);
-
-    const mapLayerDataUrls: { id: string; dataUrl: string }[] = [];
-    for (const layerId of visibleLayerIds) {
-      exportMap.setLayoutProperty(layerId, "visibility", "visible");
-      await waitForMapIdle(exportMap);
-      mapLayerDataUrls.push({
-        id: layerId,
-        dataUrl: renderMapCanvasToDataUrl(
-          exportMap.getCanvas(),
-          exportWidth,
-          exportHeight,
-        ),
-      });
-      exportMap.setLayoutProperty(layerId, "visibility", "none");
-      await waitForMapIdle(exportMap);
-    }
-
-    for (const layerId of layerIds) {
-      const visibility = originalVisibility.get(layerId) ?? "visible";
-      exportMap.setLayoutProperty(layerId, "visibility", visibility);
-    }
-    await waitForMapIdle(exportMap);
+    // Falls back to the previous per-layer raster snapshots when the style
+    // produced no queryable geometry, so the export is never blank.
+    const mapLayerDataUrls = vectorMapLayers
+      ? []
+      : await captureMapLayersAsDataUrls(exportMap, exportWidth, exportHeight);
 
     const overlayLayers: { id: string; dataUrl: string }[] = [];
 
@@ -261,26 +301,29 @@ export async function createLayeredSvgBlobFromMap({
       }),
     });
 
-    const mapLayerGroups = mapLayerDataUrls
-      .map(
-        (layer) => `<g id="map-layer-${sanitizeLayerId(layer.id)}">
-  <image href="${layer.dataUrl}" width="${exportWidth}" height="${exportHeight}" preserveAspectRatio="none" />
-</g>`,
-      )
-      .join("\n");
+    const toImageLayer = (layer: { id: string; dataUrl: string }) => ({
+      id: layer.id,
+      markup: `<image href="${layer.dataUrl}" width="${exportWidth}" height="${exportHeight}" preserveAspectRatio="none" />`,
+    });
 
-    const overlayGroups = overlayLayers
-      .map(
-        (layer) => `<g id="overlay-layer-${sanitizeLayerId(layer.id)}">
-  <image href="${layer.dataUrl}" width="${exportWidth}" height="${exportHeight}" preserveAspectRatio="none" />
-</g>`,
-      )
-      .join("\n");
+    const mapGroups = toSvgGroups(
+      "map-layer",
+      vectorMapLayers ?? mapLayerDataUrls.map(toImageLayer),
+    );
+    const overlayGroups = toSvgGroups(
+      "overlay-layer",
+      overlayLayers.map(toImageLayer),
+    );
 
+    // Vector geometry extends past the poster edge; the clip keeps the artwork
+    // inside the page instead of relying on viewBox overflow behaviour.
     const svg = `<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="${exportWidth}" height="${exportHeight}" viewBox="0 0 ${exportWidth} ${exportHeight}">
-${mapLayerGroups}
+<defs><clipPath id="poster-frame"><rect width="${exportWidth}" height="${exportHeight}" /></clipPath></defs>
+<g clip-path="url(#poster-frame)">
+${mapGroups}
 ${overlayGroups}
+</g>
 </svg>`;
 
     return new Blob([svg], { type: "image/svg+xml;charset=utf-8" });

--- a/src/features/export/infrastructure/styleExpression.ts
+++ b/src/features/export/infrastructure/styleExpression.ts
@@ -1,0 +1,100 @@
+/**
+ * Minimal reader for the paint values `generateMapStyle` produces.
+ *
+ * MapLibre keeps style expressions unevaluated, but an SVG export has to write
+ * concrete numbers. Only the two shapes the generator emits are handled —
+ * constants and zoom-driven linear interpolations. Anything else resolves to
+ * `undefined` so callers fall back to a documented default instead of guessing.
+ */
+
+function interpolateStops(stops: unknown[], zoom: number): number | undefined {
+  if (stops.length < 2 || stops.length % 2 !== 0) {
+    return undefined;
+  }
+
+  const pairs: [number, number][] = [];
+  for (let index = 0; index < stops.length; index += 2) {
+    const stopZoom = Number(stops[index]);
+    const stopValue = Number(stops[index + 1]);
+    if (!Number.isFinite(stopZoom) || !Number.isFinite(stopValue)) {
+      return undefined;
+    }
+    pairs.push([stopZoom, stopValue]);
+  }
+
+  const first = pairs[0];
+  const last = pairs[pairs.length - 1];
+  if (zoom <= first[0]) return first[1];
+  if (zoom >= last[0]) return last[1];
+
+  for (let index = 1; index < pairs.length; index += 1) {
+    const [stopZoom, stopValue] = pairs[index];
+    if (zoom > stopZoom) continue;
+
+    const [previousZoom, previousValue] = pairs[index - 1];
+    const span = stopZoom - previousZoom;
+    if (span <= 0) return stopValue;
+    return previousValue + ((stopValue - previousValue) * (zoom - previousZoom)) / span;
+  }
+
+  return last[1];
+}
+
+export function resolveStyleValue(
+  value: unknown,
+  zoom: number,
+): number | string | boolean | number[] | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (
+    typeof value === "number" ||
+    typeof value === "string" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  // Literal numeric arrays (line-dasharray) carry no operator head.
+  if (value.every((entry) => typeof entry === "number")) {
+    return value as number[];
+  }
+
+  if (value[0] !== "interpolate") {
+    return undefined;
+  }
+
+  const [, interpolation, input, ...stops] = value;
+  const isLinear = Array.isArray(interpolation) && interpolation[0] === "linear";
+  const isZoomDriven = Array.isArray(input) && input[0] === "zoom";
+  if (!isLinear || !isZoomDriven) {
+    return undefined;
+  }
+
+  return interpolateStops(stops, zoom);
+}
+
+export function resolveNumber(
+  value: unknown,
+  zoom: number,
+  fallback: number,
+): number {
+  const resolved = resolveStyleValue(value, zoom);
+  return typeof resolved === "number" && Number.isFinite(resolved)
+    ? resolved
+    : fallback;
+}
+
+export function resolveColor(
+  value: unknown,
+  zoom: number,
+  fallback: string,
+): string {
+  const resolved = resolveStyleValue(value, zoom);
+  return typeof resolved === "string" && resolved.trim() ? resolved : fallback;
+}

--- a/src/features/export/infrastructure/vectorMapSvg.ts
+++ b/src/features/export/infrastructure/vectorMapSvg.ts
@@ -1,0 +1,301 @@
+import type { Map as MaplibreMap } from "maplibre-gl";
+import type { MarkerProjectionInput } from "@/features/markers/domain/types";
+import { projectMarkerToCanvas } from "@/features/markers/infrastructure/projection";
+import { resolveColor, resolveNumber, resolveStyleValue } from "./styleExpression";
+
+/** One decimal is well below a printed dot at 300 DPI and roughly halves file size. */
+const COORDINATE_PRECISION = 1;
+
+/** Geometry this far outside the poster cannot contribute, not even via stroke width. */
+const CULL_MARGIN_PX = 64;
+
+const DEFAULT_LINE_WIDTH = 1;
+const DEFAULT_COLOR = "#000000";
+
+type Projector = (lon: number, lat: number) => { x: number; y: number };
+
+interface CullRect {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+export interface VectorMapSvgOptions {
+  map: MaplibreMap;
+  exportWidth: number;
+  exportHeight: number;
+  /** Projection input sized to the render canvas, as used for markers. */
+  projection: MarkerProjectionInput;
+  /** Render canvas to export canvas scale, applied to positions and widths. */
+  scaleX: number;
+  scaleY: number;
+}
+
+export interface VectorMapLayer {
+  id: string;
+  markup: string;
+}
+
+function escapeAttribute(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
+}
+
+function formatCoordinate(value: number): string {
+  return value.toFixed(COORDINATE_PRECISION);
+}
+
+function buildSubpath(
+  positions: unknown,
+  project: Projector,
+  close: boolean,
+  cull: CullRect,
+): string {
+  if (!Array.isArray(positions) || positions.length < 2) {
+    return "";
+  }
+
+  const points: [number, number][] = [];
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+
+  for (const position of positions) {
+    if (!Array.isArray(position) || position.length < 2) continue;
+    const lon = Number(position[0]);
+    const lat = Number(position[1]);
+    if (!Number.isFinite(lon) || !Number.isFinite(lat)) continue;
+
+    const { x, y } = project(lon, lat);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+
+    points.push([x, y]);
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+  }
+
+  if (points.length < 2) {
+    return "";
+  }
+
+  if (
+    maxX < cull.minX ||
+    minX > cull.maxX ||
+    maxY < cull.minY ||
+    minY > cull.maxY
+  ) {
+    return "";
+  }
+
+  let data = `M${formatCoordinate(points[0][0])} ${formatCoordinate(points[0][1])}`;
+  for (let index = 1; index < points.length; index += 1) {
+    data += `L${formatCoordinate(points[index][0])} ${formatCoordinate(points[index][1])}`;
+  }
+
+  return close ? `${data}Z` : data;
+}
+
+function geometryToPathData(
+  geometry: GeoJSON.Geometry | null | undefined,
+  project: Projector,
+  cull: CullRect,
+): string {
+  if (!geometry) return "";
+
+  switch (geometry.type) {
+    case "LineString":
+      return buildSubpath(geometry.coordinates, project, false, cull);
+    case "MultiLineString":
+      return geometry.coordinates
+        .map((line) => buildSubpath(line, project, false, cull))
+        .join("");
+    case "Polygon":
+      return geometry.coordinates
+        .map((ring) => buildSubpath(ring, project, true, cull))
+        .join("");
+    case "MultiPolygon":
+      return geometry.coordinates
+        .flat()
+        .map((ring) => buildSubpath(ring, project, true, cull))
+        .join("");
+    default:
+      return "";
+  }
+}
+
+function isLayerVisibleAtZoom(layer: any, zoom: number): boolean {
+  if ((layer.layout?.visibility ?? "visible") === "none") return false;
+  if (typeof layer.minzoom === "number" && zoom < layer.minzoom) return false;
+  if (typeof layer.maxzoom === "number" && zoom >= layer.maxzoom) return false;
+  return true;
+}
+
+function renderBackground(
+  layer: any,
+  zoom: number,
+  width: number,
+  height: number,
+): string {
+  const color = resolveColor(layer.paint?.["background-color"], zoom, DEFAULT_COLOR);
+  const opacity = resolveNumber(layer.paint?.["background-opacity"], zoom, 1);
+  if (opacity <= 0) return "";
+
+  return (
+    `<rect width="${width}" height="${height}" fill="${escapeAttribute(color)}"` +
+    `${opacity < 1 ? ` opacity="${opacity}"` : ""} />`
+  );
+}
+
+function renderLinePaths(
+  layer: any,
+  features: GeoJSON.Feature[],
+  zoom: number,
+  project: Projector,
+  cull: CullRect,
+  widthScale: number,
+): string {
+  const strokeWidth =
+    resolveNumber(layer.paint?.["line-width"], zoom, DEFAULT_LINE_WIDTH) * widthScale;
+  if (strokeWidth <= 0) return "";
+
+  const stroke = resolveColor(layer.paint?.["line-color"], zoom, DEFAULT_COLOR);
+  const lineCap = layer.layout?.["line-cap"] ?? "butt";
+  const lineJoin = layer.layout?.["line-join"] ?? "miter";
+
+  const dashPattern = resolveStyleValue(layer.paint?.["line-dasharray"], zoom);
+  // MapLibre expresses dashes in line-width units, SVG in user units.
+  const dashArray = Array.isArray(dashPattern)
+    ? dashPattern.map((entry) => (entry * strokeWidth).toFixed(2)).join(" ")
+    : "";
+
+  const paths: string[] = [];
+  for (const feature of features) {
+    const data = geometryToPathData(feature.geometry, project, cull);
+    if (data) paths.push(`<path d="${data}" />`);
+  }
+  if (paths.length === 0) return "";
+
+  return (
+    `<g fill="none" stroke="${escapeAttribute(stroke)}" stroke-width="${strokeWidth.toFixed(2)}"` +
+    ` stroke-linecap="${escapeAttribute(String(lineCap))}"` +
+    ` stroke-linejoin="${escapeAttribute(String(lineJoin))}"` +
+    `${dashArray ? ` stroke-dasharray="${dashArray}"` : ""}>` +
+    `${paths.join("")}</g>`
+  );
+}
+
+function renderFillPaths(
+  layer: any,
+  features: GeoJSON.Feature[],
+  zoom: number,
+  project: Projector,
+  cull: CullRect,
+): string {
+  const fill = resolveColor(layer.paint?.["fill-color"], zoom, DEFAULT_COLOR);
+
+  const paths: string[] = [];
+  for (const feature of features) {
+    const data = geometryToPathData(feature.geometry, project, cull);
+    if (data) paths.push(`<path d="${data}" />`);
+  }
+  if (paths.length === 0) return "";
+
+  // evenodd keeps polygon holes correct without relying on ring winding order,
+  // which vector tiles do not guarantee.
+  return (
+    `<g fill="${escapeAttribute(fill)}" fill-rule="evenodd" stroke="none">` +
+    `${paths.join("")}</g>`
+  );
+}
+
+/**
+ * Redraws the map layers of `map` as SVG geometry instead of a rasterised
+ * snapshot, so the exported poster stays editable and resolution independent.
+ *
+ * Returns null when the style yields no drawable geometry, which lets the
+ * caller keep the raster output rather than emit an empty poster.
+ *
+ * Known trade-offs:
+ * - Features are read through `querySourceFeatures`, so geometry that spans a
+ *   tile boundary is returned once per tile. Layer opacity is therefore applied
+ *   to the group rather than to each path: the group composites as a unit, so
+ *   the overlap cannot darken seams.
+ * - Only tiles currently loaded for the export view contribute, which is
+ *   exactly the poster's own extent.
+ */
+export function renderMapLayersAsSvg({
+  map,
+  exportWidth,
+  exportHeight,
+  projection,
+  scaleX,
+  scaleY,
+}: VectorMapSvgOptions): VectorMapLayer[] | null {
+  const style = map.getStyle();
+  const layers = style?.layers ?? [];
+  const zoom = projection.zoom;
+
+  const project: Projector = (lon, lat) => {
+    const point = projectMarkerToCanvas(lat, lon, projection);
+    return { x: point.x * scaleX, y: point.y * scaleY };
+  };
+
+  const cull: CullRect = {
+    minX: -CULL_MARGIN_PX,
+    minY: -CULL_MARGIN_PX,
+    maxX: exportWidth + CULL_MARGIN_PX,
+    maxY: exportHeight + CULL_MARGIN_PX,
+  };
+
+  const rendered: VectorMapLayer[] = [];
+  let featureCount = 0;
+
+  for (const layer of layers as any[]) {
+    if (!isLayerVisibleAtZoom(layer, zoom)) continue;
+
+    if (layer.type === "background") {
+      const markup = renderBackground(layer, zoom, exportWidth, exportHeight);
+      if (markup) rendered.push({ id: layer.id, markup });
+      continue;
+    }
+
+    if (layer.type !== "line" && layer.type !== "fill") continue;
+    if (!layer.source) continue;
+
+    const opacityKey = layer.type === "line" ? "line-opacity" : "fill-opacity";
+    const opacity = resolveNumber(layer.paint?.[opacityKey], zoom, 1);
+    // Zero opacity is how the style disables sub-layers such as road casings.
+    if (opacity <= 0) continue;
+
+    let features: GeoJSON.Feature[];
+    try {
+      features = map.querySourceFeatures(layer.source, {
+        sourceLayer: layer["source-layer"],
+        filter: layer.filter,
+      }) as unknown as GeoJSON.Feature[];
+    } catch {
+      // A source that cannot be queried simply contributes nothing.
+      continue;
+    }
+
+    if (features.length === 0) continue;
+    featureCount += features.length;
+
+    const body =
+      layer.type === "line"
+        ? renderLinePaths(layer, features, zoom, project, cull, scaleX)
+        : renderFillPaths(layer, features, zoom, project, cull);
+
+    if (body) {
+      rendered.push({
+        id: layer.id,
+        markup: opacity < 1 ? `<g opacity="${opacity.toFixed(3)}">${body}</g>` : body,
+      });
+    }
+  }
+
+  return featureCount > 0 ? rendered : null;
+}

--- a/src/features/location/domain/boundary.ts
+++ b/src/features/location/domain/boundary.ts
@@ -1,0 +1,45 @@
+import { clamp } from "@/shared/geo/math";
+
+/** Rough meters per degree of latitude, good enough to size a simplification. */
+const METERS_PER_DEGREE = 111_320;
+
+/**
+ * Boundary detail only has to survive the poster's own framing, so the
+ * simplification tolerance tracks the visible extent rather than using a fixed
+ * value. Without it an unsimplified country outline is several megabytes.
+ *
+ * `distance` is the map half-width, so a 300 DPI poster renders roughly
+ * `distance / 1200` meters per pixel. Dividing by 600 keeps the simplification
+ * error around two exported pixels.
+ */
+const TOLERANCE_EXTENT_DIVISOR = 600;
+const MIN_TOLERANCE_DEG = 0.00002;
+const MAX_TOLERANCE_DEG = 0.05;
+
+/**
+ * Tolerances are snapped to a doubling scale so nudging the distance slider
+ * reuses a cached boundary instead of issuing a new request per pixel.
+ */
+function snapToDoublingScale(toleranceDeg: number): number {
+  const steps = Math.ceil(Math.log2(toleranceDeg / MIN_TOLERANCE_DEG));
+  return MIN_TOLERANCE_DEG * Math.pow(2, Math.max(steps, 0));
+}
+
+export function resolveBoundaryTolerance(distanceMeters: number): number {
+  const extentDeg = Number(distanceMeters) / METERS_PER_DEGREE;
+  if (!Number.isFinite(extentDeg) || extentDeg <= 0) {
+    return MIN_TOLERANCE_DEG;
+  }
+
+  const tolerance = clamp(
+    extentDeg / TOLERANCE_EXTENT_DIVISOR,
+    MIN_TOLERANCE_DEG,
+    MAX_TOLERANCE_DEG,
+  );
+
+  return clamp(
+    snapToDoublingScale(tolerance),
+    MIN_TOLERANCE_DEG,
+    MAX_TOLERANCE_DEG,
+  );
+}

--- a/src/features/location/domain/ports.ts
+++ b/src/features/location/domain/ports.ts
@@ -1,4 +1,4 @@
-import type { Location } from "./types";
+import type { Location, LocationBoundary } from "./types";
 
 export interface IGeocodePort {
   searchLocations(query: string, limit?: number, signal?: AbortSignal): Promise<Location[]>;
@@ -8,6 +8,14 @@ export interface IGeocodePort {
     city: string,
     country: string,
   ): Promise<{ lat: number; lon: number; displayName: string }>;
+  /**
+   * Resolves the administrative outline of a location.
+   * Returns null when the place has no polygon (single nodes, POIs).
+   */
+  fetchLocationBoundary(
+    location: Location,
+    toleranceDeg: number,
+  ): Promise<LocationBoundary | null>;
 }
 
 /** @internal Return type for geocodeCity. Ports allow alternative shapes. */

--- a/src/features/location/domain/types.ts
+++ b/src/features/location/domain/types.ts
@@ -7,6 +7,19 @@ export interface Location {
   continent?: string;
   lat: number;
   lon: number;
+  /** OSM element the result resolves to — needed to look up its boundary. */
+  osmType?: string;
+  osmId?: number;
 }
 
 export interface SearchResult extends Location {}
+
+/**
+ * Exterior rings of a location's administrative area, in [lon, lat] order.
+ * Interior rings (lakes, enclaves) are dropped: they are negligible at poster
+ * scale and nested rings are not representable in a single mask polygon.
+ */
+export interface LocationBoundary {
+  id: string;
+  rings: number[][][];
+}

--- a/src/features/location/infrastructure/cacheKeys.ts
+++ b/src/features/location/infrastructure/cacheKeys.ts
@@ -9,6 +9,13 @@ export function getGeocodeCacheKey(lookup: string): string {
   return `geocode:location:${lookup.toLowerCase()}`;
 }
 
+export function getBoundaryCacheKey(
+  osmRef: string,
+  toleranceDeg: number,
+): string {
+  return `boundary:${osmRef}:tolerance:${toleranceDeg}`;
+}
+
 export function getReverseGeocodeCacheKey(lat: number, lon: number): string {
   const roundedLat = lat.toFixed(4);
   const roundedLon = lon.toFixed(4);

--- a/src/features/location/infrastructure/locationParser.ts
+++ b/src/features/location/infrastructure/locationParser.ts
@@ -6,10 +6,21 @@ interface NominatimEntry {
   display_name?: string;
   label?: string;
   place_id?: number | string;
+  osm_type?: string;
+  osm_id?: number | string;
+  osmType?: string;
+  osmId?: number | string;
   city?: string;
   country?: string;
   address?: Record<string, string>;
 }
+
+interface NominatimGeometry {
+  type?: string;
+  coordinates?: unknown;
+}
+
+const MIN_RING_POSITIONS = 4;
 
 function inferContinentFromCoordinates(lat: number, lon: number): string {
   if (!Number.isFinite(lat) || !Number.isFinite(lon)) return "";
@@ -77,6 +88,13 @@ export function normalizeLocationResult(
     pickFirstAddressValue(address, ["continent"]) ||
     inferContinentFromCoordinates(lat, lon);
 
+  // Cached entries are re-normalized from a previous output, so both the raw
+  // Nominatim keys and the normalized ones have to round-trip.
+  const osmType = String(entry.osm_type ?? entry.osmType ?? "")
+    .trim()
+    .toLowerCase();
+  const osmId = Number(entry.osm_id ?? entry.osmId);
+
   return {
     id: String(entry.place_id ?? label),
     label,
@@ -86,7 +104,56 @@ export function normalizeLocationResult(
     continent,
     lat,
     lon,
+    ...(osmType ? { osmType } : {}),
+    ...(Number.isInteger(osmId) && osmId > 0 ? { osmId } : {}),
   };
+}
+
+function toRing(value: unknown): number[][] | null {
+  if (!Array.isArray(value) || value.length < MIN_RING_POSITIONS) {
+    return null;
+  }
+
+  const ring: number[][] = [];
+  for (const position of value) {
+    if (!Array.isArray(position) || position.length < 2) {
+      return null;
+    }
+    const lon = Number(position[0]);
+    const lat = Number(position[1]);
+    if (!Number.isFinite(lon) || !Number.isFinite(lat)) {
+      return null;
+    }
+    ring.push([lon, lat]);
+  }
+
+  return ring;
+}
+
+/**
+ * Extracts the exterior ring of every polygon in a Nominatim `geojson` value.
+ * Non-area geometries (points, lines) yield an empty list.
+ */
+export function parseBoundaryRings(geometry: unknown): number[][][] {
+  const geojson = (geometry ?? {}) as NominatimGeometry;
+  const { coordinates } = geojson;
+
+  if (geojson.type === "Polygon" && Array.isArray(coordinates)) {
+    const ring = toRing(coordinates[0]);
+    return ring ? [ring] : [];
+  }
+
+  if (geojson.type === "MultiPolygon" && Array.isArray(coordinates)) {
+    const rings: number[][][] = [];
+    for (const polygon of coordinates) {
+      if (!Array.isArray(polygon)) continue;
+      const ring = toRing(polygon[0]);
+      if (ring) rings.push(ring);
+    }
+    return rings;
+  }
+
+  return [];
 }
 
 export function parseLocationResponseItems(payload: unknown): SearchResult[] {

--- a/src/features/location/infrastructure/nominatimAdapter.ts
+++ b/src/features/location/infrastructure/nominatimAdapter.ts
@@ -1,21 +1,53 @@
 import type { ICache } from "@/core/cache/ports";
 import type { IHttp } from "@/core/http/ports";
 import type { IGeocodePort } from "../domain/ports";
-import type { SearchResult } from "../domain/types";
+import type { Location, LocationBoundary, SearchResult } from "../domain/types";
 import {
   normalizeLocationResult,
+  parseBoundaryRings,
   parseLocationResponseItems,
 } from "./locationParser";
 import { GEOCODE_TTL_MS, LOCATION_SEARCH_TTL_MS } from "./constants";
 import {
+  getBoundaryCacheKey,
   getGeocodeCacheKey,
   getLocationSearchCacheKey,
   getReverseGeocodeCacheKey,
 } from "./cacheKeys";
 
+/** Nominatim `osm_ids` uses a single-letter prefix per OSM element type. */
+const OSM_TYPE_PREFIXES: Record<string, string> = {
+  relation: "R",
+  way: "W",
+  node: "N",
+};
+
+/**
+ * Outlines share the localStorage quota with the geocoding caches, so an
+ * unusually large one is used but not persisted.
+ */
+const MAX_CACHEABLE_BOUNDARY_POSITIONS = 20_000;
+
+function countPositions(rings: number[][][]): number {
+  return rings.reduce((total, ring) => total + ring.length, 0);
+}
+
 // Deduplicate concurrent requests for the same query/coordinates
 const inFlightSearchRequests = new Map<string, Promise<SearchResult[]>>();
 const inFlightReverseRequests = new Map<string, Promise<SearchResult>>();
+const inFlightBoundaryRequests = new Map<
+  string,
+  Promise<LocationBoundary | null>
+>();
+
+function resolveOsmRef(location: Location | null | undefined): string {
+  const prefix = OSM_TYPE_PREFIXES[String(location?.osmType ?? "").toLowerCase()];
+  const osmId = Number(location?.osmId);
+  if (!prefix || !Number.isInteger(osmId) || osmId <= 0) {
+    return "";
+  }
+  return `${prefix}${osmId}`;
+}
 
 export function createNominatimAdapter(
   http: IHttp,
@@ -144,5 +176,66 @@ export function createNominatimAdapter(
     return promise;
   }
 
-  return { searchLocations, geocodeLocation, reverseGeocode, geocodeCity };
+  /**
+   * Nominatim only returns geometry when `polygon_threshold` keeps it small —
+   * an unsimplified country outline runs into megabytes — so the caller-provided
+   * tolerance is always sent and is part of the cache key.
+   */
+  async function fetchLocationBoundary(
+    location: Location,
+    toleranceDeg: number,
+  ): Promise<LocationBoundary | null> {
+    const osmRef = resolveOsmRef(location);
+    if (!osmRef) {
+      return null;
+    }
+
+    if (!Number.isFinite(toleranceDeg) || toleranceDeg <= 0) {
+      throw new Error("A positive simplification tolerance is required.");
+    }
+
+    const cacheKey = getBoundaryCacheKey(osmRef, toleranceDeg);
+    const cached = cache.read<LocationBoundary>(cacheKey, GEOCODE_TTL_MS);
+    if (cached && Array.isArray(cached.rings)) {
+      return cached.rings.length > 0 ? cached : null;
+    }
+
+    if (inFlightBoundaryRequests.has(cacheKey)) {
+      return inFlightBoundaryRequests.get(cacheKey)!;
+    }
+
+    const url =
+      "https://nominatim.openstreetmap.org/lookup?" +
+      `format=jsonv2&polygon_geojson=1&polygon_threshold=${toleranceDeg}` +
+      `&osm_ids=${encodeURIComponent(osmRef)}`;
+
+    const promise = http
+      .get(url, { headers: { Accept: "application/json" } }, 20_000)
+      .then(async (response) => {
+        const data = await response.json();
+        const entry = Array.isArray(data) ? data[0] : null;
+        const rings = parseBoundaryRings(entry?.geojson);
+        const boundary: LocationBoundary = { id: osmRef, rings };
+
+        // Cached either way: a place without an outline stays without one.
+        if (countPositions(rings) <= MAX_CACHEABLE_BOUNDARY_POSITIONS) {
+          cache.write(cacheKey, boundary);
+        }
+        return rings.length > 0 ? boundary : null;
+      })
+      .finally(() => {
+        inFlightBoundaryRequests.delete(cacheKey);
+      });
+
+    inFlightBoundaryRequests.set(cacheKey, promise);
+    return promise;
+  }
+
+  return {
+    searchLocations,
+    geocodeLocation,
+    reverseGeocode,
+    geocodeCity,
+    fetchLocationBoundary,
+  };
 }

--- a/src/features/map/application/useLocationBoundary.ts
+++ b/src/features/map/application/useLocationBoundary.ts
@@ -1,0 +1,56 @@
+import { useEffect } from "react";
+import { fetchLocationBoundary } from "@/core/services";
+import { resolveBoundaryTolerance } from "@/features/location/domain/boundary";
+import type { SearchResult } from "@/features/location/domain/types";
+import type { PosterAction } from "@/features/poster/application/posterReducer";
+
+/**
+ * Keeps the administrative outline of the selected location in state while the
+ * boundary clip is enabled.
+ *
+ * A boundary is only available for locations picked from search, since the
+ * lookup keys off the OSM element the suggestion resolved to. Typed
+ * coordinates and map drags have nothing to look up.
+ */
+export function useLocationBoundary(
+  enabled: boolean,
+  selectedLocation: SearchResult | null,
+  distanceMeters: number,
+  dispatch: React.Dispatch<PosterAction>,
+): void {
+  useEffect(() => {
+    if (!enabled || !selectedLocation) {
+      dispatch({ type: "SET_LOCATION_BOUNDARY", boundary: null, status: "idle" });
+      return;
+    }
+
+    let isCancelled = false;
+    dispatch({ type: "SET_LOCATION_BOUNDARY", boundary: null, status: "loading" });
+
+    void fetchLocationBoundary(
+      selectedLocation,
+      resolveBoundaryTolerance(distanceMeters),
+    )
+      .then((boundary) => {
+        if (isCancelled) return;
+        dispatch({
+          type: "SET_LOCATION_BOUNDARY",
+          boundary,
+          status: boundary ? "ready" : "unavailable",
+        });
+      })
+      .catch(() => {
+        if (isCancelled) return;
+        // A failed lookup leaves the poster unclipped rather than blocking it.
+        dispatch({
+          type: "SET_LOCATION_BOUNDARY",
+          boundary: null,
+          status: "unavailable",
+        });
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [enabled, selectedLocation, distanceMeters, dispatch]);
+}

--- a/src/features/map/domain/boundaryMask.ts
+++ b/src/features/map/domain/boundaryMask.ts
@@ -1,0 +1,45 @@
+/**
+ * MapLibre cannot clip vector layers to an arbitrary polygon, so restricting a
+ * poster to one administrative area is done by painting everything *outside*
+ * it: a world-sized ring with the boundary rings punched out as holes.
+ *
+ * The map data outside the boundary is still fetched, only hidden — filtering
+ * at tile level would require geometry operations the renderer does not expose.
+ */
+
+/** Web Mercator cuts off just past +/-85 degrees, so the ring stops there. */
+const WORLD_LATITUDE_LIMIT = 85.0511;
+
+const WORLD_RING: number[][] = [
+  [-180, -WORLD_LATITUDE_LIMIT],
+  [180, -WORLD_LATITUDE_LIMIT],
+  [180, WORLD_LATITUDE_LIMIT],
+  [-180, WORLD_LATITUDE_LIMIT],
+  [-180, -WORLD_LATITUDE_LIMIT],
+];
+
+export interface BoundaryMaskFeature {
+  type: "Feature";
+  properties: Record<string, unknown>;
+  geometry: {
+    type: "Polygon";
+    coordinates: number[][][];
+  };
+}
+
+export function createBoundaryMask(
+  rings: number[][][] | null | undefined,
+): BoundaryMaskFeature | null {
+  if (!Array.isArray(rings) || rings.length === 0) {
+    return null;
+  }
+
+  return {
+    type: "Feature",
+    properties: {},
+    geometry: {
+      type: "Polygon",
+      coordinates: [WORLD_RING, ...rings],
+    },
+  };
+}

--- a/src/features/map/infrastructure/maplibreStyle.ts
+++ b/src/features/map/infrastructure/maplibreStyle.ts
@@ -14,6 +14,7 @@ const SOURCE_MAX_ZOOM = 14;
 
 const BUILDING_BLEND_FACTOR = 0.14;
 const BUILDING_FILL_OPACITY = 0.84;
+const BOUNDARY_BLEND_FACTOR = 0.62;
 const MAP_BUILDING_MIN_ZOOM_DEFAULT = 8;
 const MAP_BUILDING_MIN_ZOOM_PRESERVE = 8.2;
 const DETAIL_PRESERVE_DISTANCE_METERS = 30_000;
@@ -31,6 +32,16 @@ const MAP_RAIL_WIDTH_STOPS: [number, number][] = [
   [10, 1],
   [18, 1.5],
 ];
+
+const MAP_BOUNDARY_WIDTH_STOPS: [number, number][] = [
+  [0, 0.3],
+  [4, 0.6],
+  [8, 1],
+  [14, 1.7],
+];
+
+/** OpenMapTiles admin levels 0-2 are national borders; 3+ are subnational. */
+const MAP_BOUNDARY_COUNTRY_MAX_ADMIN_LEVEL = 2;
 
 /**
  * Road classes are intentionally broad in minor/detail buckets so dense road texture
@@ -212,6 +223,25 @@ function lineSubclassFilter(subclasses: string[]): any {
   ];
 }
 
+/**
+ * Maritime borders run far offshore and read as noise on a poster, so only the
+ * land-side national borders are kept. `to-number` guards against tiles that
+ * encode `maritime` as a boolean instead of 0/1.
+ */
+function countryBoundaryFilter(): any {
+  return [
+    "all",
+    LINE_GEOMETRY_FILTER,
+    ["has", "admin_level"],
+    [
+      "<=",
+      ["to-number", ["get", "admin_level"]],
+      MAP_BOUNDARY_COUNTRY_MAX_ADMIN_LEVEL,
+    ],
+    ["!=", ["to-number", ["get", "maritime"]], 1],
+  ];
+}
+
 export function generateMapStyle(
   theme: ResolvedTheme,
   options?: {
@@ -226,6 +256,7 @@ export function generateMapStyle(
     includeRoadMinorLow?: boolean;
     includeRoadOutline?: boolean;
     includeCycleways?: boolean;
+    includeCountryBorders?: boolean;
     distanceMeters?: number;
   },
 ): StyleSpecification {
@@ -248,7 +279,14 @@ export function generateMapStyle(
   const includeRoadMinorLow = options?.includeRoadMinorLow ?? true;
   const includeRoadOutline = options?.includeRoadOutline ?? true;
   const includeCycleways = options?.includeCycleways ?? false;
+  const includeCountryBorders = options?.includeCountryBorders ?? false;
   const buildingMinZoom = resolveBuildingMinZoom(options?.distanceMeters);
+
+  const boundaryColor = blendHex(
+    theme.map.land || "#ffffff",
+    theme.ui.text || "#111111",
+    BOUNDARY_BLEND_FACTOR,
+  );
 
   const minorHighCasingStops = scaledStops(
     MAP_ROAD_MINOR_HIGH_DETAIL_WIDTH_STOPS,
@@ -287,6 +325,7 @@ export function generateMapStyle(
     MAP_ROAD_PATH_DETAIL_WIDTH_STOPS,
   );
   const cyclewayWidthStops = compensateLineWidthStops(MAP_CYCLEWAY_WIDTH_STOPS);
+  const boundaryWidthStops = compensateLineWidthStops(MAP_BOUNDARY_WIDTH_STOPS);
   const roadMajorWidthStops = compensateLineWidthStops(
     MAP_ROAD_MAJOR_WIDTH_STOPS,
   );
@@ -739,6 +778,32 @@ export function generateMapStyle(
         layout: {
           visibility: includeCycleways ? ("visible" as const) : ("none" as const),
           "line-cap": "round" as const,
+          "line-join": "round" as const,
+        },
+      },
+
+      // Topmost so national borders stay readable over any enabled layer.
+      {
+        id: "boundary-country",
+        source: SOURCE_ID,
+        "source-layer": "boundary",
+        type: "line" as const,
+        filter: countryBoundaryFilter(),
+        paint: {
+          "line-color": boundaryColor,
+          "line-width": widthExpr(boundaryWidthStops),
+          "line-opacity": opacityExpr([
+            [0, 0.7],
+            [8, 0.82],
+            [14, 0.9],
+          ]),
+          "line-dasharray": [4, 2],
+        },
+        layout: {
+          visibility: includeCountryBorders
+            ? ("visible" as const)
+            : ("none" as const),
+          "line-cap": "butt" as const,
           "line-join": "round" as const,
         },
       },

--- a/src/features/map/infrastructure/maplibreStyle.ts
+++ b/src/features/map/infrastructure/maplibreStyle.ts
@@ -1,10 +1,13 @@
 import type { ResolvedTheme } from "@/features/theme/domain/types";
+import type { BoundaryMaskFeature } from "@/features/map/domain/boundaryMask";
 import { MAP_OVERZOOM_SCALE } from "@/features/map/infrastructure/constants";
 import { blendHex } from "@/shared/utils/color";
 import type { StyleSpecification } from "maplibre-gl";
 
 const OPENFREEMAP_SOURCE = "https://tiles.openfreemap.org/planet";
 const SOURCE_ID = "openfreemap";
+const BOUNDARY_MASK_SOURCE_ID = "boundary-mask";
+const BOUNDARY_MASK_LAYER_ID = "boundary-mask";
 
 /**
  * OpenFreeMap is OpenMapTiles-based and can generalize data at low zooms.
@@ -257,6 +260,7 @@ export function generateMapStyle(
     includeRoadOutline?: boolean;
     includeCycleways?: boolean;
     includeCountryBorders?: boolean;
+    boundaryMask?: BoundaryMaskFeature | null;
     distanceMeters?: number;
   },
 ): StyleSpecification {
@@ -340,7 +344,7 @@ export function generateMapStyle(
   const roadPathColor = theme.map.roads.path;
   const roadOutlineColor = theme.map.roads.outline;
 
-  return {
+  const style: StyleSpecification = {
     version: 8,
     sources: {
       [SOURCE_ID]: {
@@ -809,4 +813,25 @@ export function generateMapStyle(
       },
     ],
   };
+
+  // Appended last so it covers every map layer. Marker, route and text
+  // overlays are drawn outside the style and stay unaffected.
+  const boundaryMask = options?.boundaryMask;
+  if (boundaryMask) {
+    style.sources[BOUNDARY_MASK_SOURCE_ID] = {
+      type: "geojson",
+      data: boundaryMask,
+    };
+    style.layers.push({
+      id: BOUNDARY_MASK_LAYER_ID,
+      source: BOUNDARY_MASK_SOURCE_ID,
+      type: "fill",
+      paint: {
+        "fill-color": theme.map.land,
+        "fill-antialias": true,
+      },
+    });
+  }
+
+  return style;
 }

--- a/src/features/map/infrastructure/maplibreStyle.ts
+++ b/src/features/map/infrastructure/maplibreStyle.ts
@@ -64,6 +64,12 @@ const MAP_ROAD_PATH_CLASSES = ["path", "pedestrian", "cycleway", "track"];
 const MAP_RAIL_CLASSES = ["rail", "transit"];
 
 /**
+ * OpenMapTiles files dedicated cycle infrastructure under class "path" with
+ * subclass "cycleway", so the cycle layer keys off subclass rather than class.
+ */
+const MAP_CYCLEWAY_SUBCLASSES = ["cycleway"];
+
+/**
  * Two-stage minor/path rendering:
  * - overview layer: very thin roads at low zoom so detail does not disappear abruptly
  * - detail layer: thicker, readable network from mid zoom upward
@@ -117,6 +123,17 @@ const MAP_ROAD_PATH_DETAIL_WIDTH_STOPS: [number, number][] = [
   [18, 1.3],
 ];
 
+/**
+ * Cycle ways sit slightly above the path bucket so the network stays legible
+ * both as a highlight over roads and as the only visible network.
+ */
+const MAP_CYCLEWAY_WIDTH_STOPS: [number, number][] = [
+  [8, 0.3],
+  [12, 0.62],
+  [16, 1.2],
+  [18, 1.9],
+];
+
 const MAP_ROAD_MAJOR_WIDTH_STOPS: [number, number][] = [
   [0, 0.36],
   [3, 0.52],
@@ -130,6 +147,7 @@ const ROAD_MINOR_DETAIL_MIN_ZOOM = 6;
 const ROAD_PATH_OVERVIEW_MIN_ZOOM = 5;
 const ROAD_PATH_DETAIL_MIN_ZOOM = 8;
 const ROAD_OVERVIEW_MAX_ZOOM = 11.8;
+const CYCLEWAY_MIN_ZOOM = 8;
 
 const LINE_GEOMETRY_FILTER = [
   "match",
@@ -186,6 +204,14 @@ function lineClassFilter(classes: string[]): any {
   ];
 }
 
+function lineSubclassFilter(subclasses: string[]): any {
+  return [
+    "all",
+    LINE_GEOMETRY_FILTER,
+    ["match", ["get", "subclass"], subclasses, true, false],
+  ];
+}
+
 export function generateMapStyle(
   theme: ResolvedTheme,
   options?: {
@@ -199,6 +225,7 @@ export function generateMapStyle(
     includeRoadPath?: boolean;
     includeRoadMinorLow?: boolean;
     includeRoadOutline?: boolean;
+    includeCycleways?: boolean;
     distanceMeters?: number;
   },
 ): StyleSpecification {
@@ -220,6 +247,7 @@ export function generateMapStyle(
   const includeRoadPath = options?.includeRoadPath ?? true;
   const includeRoadMinorLow = options?.includeRoadMinorLow ?? true;
   const includeRoadOutline = options?.includeRoadOutline ?? true;
+  const includeCycleways = options?.includeCycleways ?? false;
   const buildingMinZoom = resolveBuildingMinZoom(options?.distanceMeters);
 
   const minorHighCasingStops = scaledStops(
@@ -258,6 +286,7 @@ export function generateMapStyle(
   const roadPathDetailWidthStops = compensateLineWidthStops(
     MAP_ROAD_PATH_DETAIL_WIDTH_STOPS,
   );
+  const cyclewayWidthStops = compensateLineWidthStops(MAP_CYCLEWAY_WIDTH_STOPS);
   const roadMajorWidthStops = compensateLineWidthStops(
     MAP_ROAD_MAJOR_WIDTH_STOPS,
   );
@@ -684,6 +713,31 @@ export function generateMapStyle(
         },
         layout: {
           visibility: includeRoads ? ("visible" as const) : ("none" as const),
+          "line-cap": "round" as const,
+          "line-join": "round" as const,
+        },
+      },
+
+      // Drawn on top of the road stack and deliberately independent of the
+      // roads toggle so a cycle network can be rendered on its own.
+      {
+        id: "cycleway",
+        source: SOURCE_ID,
+        "source-layer": "transportation",
+        type: "line",
+        minzoom: CYCLEWAY_MIN_ZOOM,
+        filter: lineSubclassFilter(MAP_CYCLEWAY_SUBCLASSES),
+        paint: {
+          "line-color": theme.map.roads.major,
+          "line-width": widthExpr(cyclewayWidthStops),
+          "line-opacity": opacityExpr([
+            [8, 0.78],
+            [12, 0.88],
+            [18, 1],
+          ]),
+        },
+        layout: {
+          visibility: includeCycleways ? ("visible" as const) : ("none" as const),
           "line-cap": "round" as const,
           "line-join": "round" as const,
         },

--- a/src/features/map/ui/LayersSection.tsx
+++ b/src/features/map/ui/LayersSection.tsx
@@ -1,3 +1,4 @@
+import type { LocationBoundaryStatus } from "@/features/poster/application/posterReducer";
 import MapDimensionFields from "./MapDimensionFields";
 
 interface LayerForm {
@@ -16,6 +17,7 @@ interface LayerForm {
   includeRoadOutline: boolean;
   includeCycleways: boolean;
   includeCountryBorders: boolean;
+  clipToBoundary: boolean;
 }
 
 interface LayersSectionProps {
@@ -24,6 +26,28 @@ interface LayersSectionProps {
   minPosterCm: number;
   maxPosterCm: number;
   onNumericFieldBlur: (event: React.FocusEvent<HTMLInputElement>) => void;
+  hasSelectedLocation: boolean;
+  boundaryStatus: LocationBoundaryStatus;
+}
+
+function resolveBoundaryHint(
+  hasSelectedLocation: boolean,
+  status: LocationBoundaryStatus,
+  isEnabled: boolean,
+): string {
+  if (!hasSelectedLocation) {
+    return "Pick a place from the location search to use its boundary.";
+  }
+  if (!isEnabled) {
+    return "";
+  }
+  if (status === "loading") {
+    return "Loading boundary…";
+  }
+  if (status === "unavailable") {
+    return "No boundary outline is available for this place.";
+  }
+  return "";
 }
 
 export default function LayersSection({
@@ -32,7 +56,15 @@ export default function LayersSection({
   minPosterCm,
   maxPosterCm,
   onNumericFieldBlur,
+  hasSelectedLocation,
+  boundaryStatus,
 }: LayersSectionProps) {
+  const boundaryHint = resolveBoundaryHint(
+    hasSelectedLocation,
+    boundaryStatus,
+    Boolean(form.clipToBoundary),
+  );
+
   return (
     <section className="panel-block">
       <p className="section-summary-label">LAYERS</p>
@@ -145,6 +177,25 @@ export default function LayersSection({
           <span className="theme-switch-track" aria-hidden="true" />
         </span>
       </label>
+
+      <label
+        className={`toggle-field${hasSelectedLocation ? "" : " toggle-field--disabled"}`}
+      >
+        <span>Clip to location boundary</span>
+        <span className="theme-switch">
+          <input
+            type="checkbox"
+            name="clipToBoundary"
+            checked={Boolean(form.clipToBoundary)}
+            disabled={!hasSelectedLocation}
+            onChange={onChange}
+          />
+          <span className="theme-switch-track" aria-hidden="true" />
+        </span>
+      </label>
+      {boundaryHint ? (
+        <p className="layers-section__hint">{boundaryHint}</p>
+      ) : null}
 
       <div className="map-details-section">
         <h3 className="map-details-subtitle">Map Details</h3>

--- a/src/features/map/ui/LayersSection.tsx
+++ b/src/features/map/ui/LayersSection.tsx
@@ -15,6 +15,7 @@ interface LayerForm {
   includeRoadMinorLow: boolean;
   includeRoadOutline: boolean;
   includeCycleways: boolean;
+  includeCountryBorders: boolean;
 }
 
 interface LayersSectionProps {
@@ -126,6 +127,19 @@ export default function LayersSection({
             type="checkbox"
             name="includeAeroway"
             checked={Boolean(form.includeAeroway)}
+            onChange={onChange}
+          />
+          <span className="theme-switch-track" aria-hidden="true" />
+        </span>
+      </label>
+
+      <label className="toggle-field">
+        <span>Show country borders</span>
+        <span className="theme-switch">
+          <input
+            type="checkbox"
+            name="includeCountryBorders"
+            checked={Boolean(form.includeCountryBorders)}
             onChange={onChange}
           />
           <span className="theme-switch-track" aria-hidden="true" />

--- a/src/features/map/ui/LayersSection.tsx
+++ b/src/features/map/ui/LayersSection.tsx
@@ -14,6 +14,7 @@ interface LayerForm {
   includeRoadPath: boolean;
   includeRoadMinorLow: boolean;
   includeRoadOutline: boolean;
+  includeCycleways: boolean;
 }
 
 interface LayersSectionProps {
@@ -101,6 +102,18 @@ export default function LayersSection({
             type="checkbox"
             name="includeRail"
             checked={Boolean(form.includeRail)}
+            onChange={onChange}
+          />
+          <span className="theme-switch-track" aria-hidden="true" />
+        </span>
+      </label>
+      <label className="toggle-field">
+        <span>Show cycle ways</span>
+        <span className="theme-switch">
+          <input
+            type="checkbox"
+            name="includeCycleways"
+            checked={Boolean(form.includeCycleways)}
             onChange={onChange}
           />
           <span className="theme-switch-track" aria-hidden="true" />

--- a/src/features/poster/application/posterReducer.ts
+++ b/src/features/poster/application/posterReducer.ts
@@ -49,6 +49,7 @@ export interface PosterForm {
   includeRoadMinorLow: boolean;
   includeRoadOutline: boolean;
   includeCycleways: boolean;
+  includeCountryBorders: boolean;
   showMarkers: boolean;
   showRoutes: boolean;
 }

--- a/src/features/poster/application/posterReducer.ts
+++ b/src/features/poster/application/posterReducer.ts
@@ -1,4 +1,7 @@
-import type { SearchResult } from "@/features/location/domain/types";
+import type {
+  LocationBoundary,
+  SearchResult,
+} from "@/features/location/domain/types";
 import type {
   MarkerDefaults,
   MarkerIconDefinition,
@@ -50,9 +53,17 @@ export interface PosterForm {
   includeRoadOutline: boolean;
   includeCycleways: boolean;
   includeCountryBorders: boolean;
+  clipToBoundary: boolean;
   showMarkers: boolean;
   showRoutes: boolean;
 }
+
+/** Lifecycle of the boundary lookup backing `clipToBoundary`. */
+export type LocationBoundaryStatus =
+  | "idle"
+  | "loading"
+  | "ready"
+  | "unavailable";
 
 /* ────── App-level state ────── */
 
@@ -73,6 +84,8 @@ export interface PosterState {
   isLocationFocused: boolean;
   selectedLocation: SearchResult | null;
   userLocation: SearchResult | null;
+  locationBoundary: LocationBoundary | null;
+  locationBoundaryStatus: LocationBoundaryStatus;
   displayNameOverrides: {
     city: boolean;
     country: boolean;
@@ -101,6 +114,11 @@ export type PosterAction =
   | { type: "REMOVE_SAVED_THEME"; themeId: string }
   | { type: "SELECT_LOCATION"; location: SearchResult }
   | { type: "SET_USER_LOCATION"; location: SearchResult | null }
+  | {
+      type: "SET_LOCATION_BOUNDARY";
+      boundary: LocationBoundary | null;
+      status: LocationBoundaryStatus;
+    }
   | { type: "CLEAR_LOCATION" }
   | { type: "SET_LOCATION_FOCUSED"; focused: boolean }
   | { type: "SET_ERROR"; error: string }
@@ -167,7 +185,11 @@ export function posterReducer(
         displayNameOverrides: nextDisplayNameOverrides,
         // Clear selected location when location/lat/lon field changes
         ...(["location", "latitude", "longitude"].includes(action.name)
-          ? { selectedLocation: null }
+          ? {
+              selectedLocation: null,
+              locationBoundary: null,
+              locationBoundaryStatus: "idle" as const,
+            }
           : {}),
       };
     }
@@ -247,6 +269,9 @@ export function posterReducer(
         ...state,
         selectedLocation: action.location,
         isLocationFocused: false,
+        // The previous outline belongs to a different place.
+        locationBoundary: null,
+        locationBoundaryStatus: "idle",
         displayNameOverrides: { city: false, country: false },
         form: {
           ...state.form,
@@ -265,10 +290,25 @@ export function posterReducer(
         userLocation: action.location,
       };
 
+    case "SET_LOCATION_BOUNDARY":
+      if (
+        state.locationBoundary === action.boundary &&
+        state.locationBoundaryStatus === action.status
+      ) {
+        return state;
+      }
+      return {
+        ...state,
+        locationBoundary: action.boundary,
+        locationBoundaryStatus: action.status,
+      };
+
     case "CLEAR_LOCATION":
       return {
         ...state,
         selectedLocation: null,
+        locationBoundary: null,
+        locationBoundaryStatus: "idle",
         displayNameOverrides: { city: false, country: false },
         form: {
           ...state.form,

--- a/src/features/poster/application/posterReducer.ts
+++ b/src/features/poster/application/posterReducer.ts
@@ -48,6 +48,7 @@ export interface PosterForm {
   includeRoadPath: boolean;
   includeRoadMinorLow: boolean;
   includeRoadOutline: boolean;
+  includeCycleways: boolean;
   showMarkers: boolean;
   showRoutes: boolean;
 }

--- a/src/features/poster/ui/PosterContext.tsx
+++ b/src/features/poster/ui/PosterContext.tsx
@@ -17,7 +17,9 @@ import type { ResolvedTheme } from "@/features/theme/domain/types";
 import { getTheme } from "@/features/theme/infrastructure/themeRepository";
 import { applyThemeColorOverrides } from "@/features/theme/domain/colorPaths";
 import { generateMapStyle } from "@/features/map/infrastructure/maplibreStyle";
+import { createBoundaryMask } from "@/features/map/domain/boundaryMask";
 import { useGeolocation } from "@/features/map/application/useGeolocation";
+import { useLocationBoundary } from "@/features/map/application/useLocationBoundary";
 import type { StyleSpecification } from "maplibre-gl";
 import type { MapInstanceRef } from "@/features/map/domain/types";
 import { createDefaultMarkerSettings } from "@/features/markers/infrastructure/helpers";
@@ -89,6 +91,7 @@ export const DEFAULT_FORM: PosterForm = {
   includeRoadOutline: true,
   includeCycleways: false,
   includeCountryBorders: false,
+  clipToBoundary: false,
   showMarkers: true,
   showRoutes: true,
 };
@@ -138,6 +141,8 @@ function buildInitialState(): PosterState {
     isLocationFocused: false,
     selectedLocation: null,
     userLocation: null,
+    locationBoundary: null,
+    locationBoundaryStatus: "idle",
     displayNameOverrides: {
       city: false,
       country: false,
@@ -180,6 +185,12 @@ export function PosterProvider({ children }: { children: ReactNode }) {
   const initialUserDefaultsRef = useRef(state.userDefaults);
 
   useGeolocation(dispatch);
+  useLocationBoundary(
+    state.form.clipToBoundary,
+    state.selectedLocation,
+    Number(state.form.distance),
+    dispatch,
+  );
 
   const selectedTheme = useMemo(() => {
     const saved = state.savedThemes.find((t) => t.id === state.form.theme);
@@ -281,6 +292,14 @@ export function PosterProvider({ children }: { children: ReactNode }) {
     saveUserDefaults(state.userDefaults);
   }, [state.userDefaults]);
 
+  const boundaryMask = useMemo(
+    () =>
+      state.form.clipToBoundary
+        ? createBoundaryMask(state.locationBoundary?.rings)
+        : null,
+    [state.form.clipToBoundary, state.locationBoundary],
+  );
+
   const mapStyle = useMemo(
     () =>
       generateMapStyle(effectiveTheme, {
@@ -296,6 +315,7 @@ export function PosterProvider({ children }: { children: ReactNode }) {
         includeRoadOutline: state.form.includeRoadOutline,
         includeCycleways: state.form.includeCycleways,
         includeCountryBorders: state.form.includeCountryBorders,
+        boundaryMask,
         distanceMeters: Number(state.form.distance),
       }),
     [
@@ -312,6 +332,7 @@ export function PosterProvider({ children }: { children: ReactNode }) {
       state.form.includeRoadOutline,
       state.form.includeCycleways,
       state.form.includeCountryBorders,
+      boundaryMask,
       state.form.distance,
     ],
   );

--- a/src/features/poster/ui/PosterContext.tsx
+++ b/src/features/poster/ui/PosterContext.tsx
@@ -87,6 +87,7 @@ export const DEFAULT_FORM: PosterForm = {
   includeRoadPath: true,
   includeRoadMinorLow: true,
   includeRoadOutline: true,
+  includeCycleways: false,
   showMarkers: true,
   showRoutes: true,
 };
@@ -292,6 +293,7 @@ export function PosterProvider({ children }: { children: ReactNode }) {
         includeRoadPath: state.form.includeRoadPath,
         includeRoadMinorLow: state.form.includeRoadMinorLow,
         includeRoadOutline: state.form.includeRoadOutline,
+        includeCycleways: state.form.includeCycleways,
         distanceMeters: Number(state.form.distance),
       }),
     [
@@ -306,6 +308,7 @@ export function PosterProvider({ children }: { children: ReactNode }) {
       state.form.includeRoadPath,
       state.form.includeRoadMinorLow,
       state.form.includeRoadOutline,
+      state.form.includeCycleways,
       state.form.distance,
     ],
   );

--- a/src/features/poster/ui/PosterContext.tsx
+++ b/src/features/poster/ui/PosterContext.tsx
@@ -88,6 +88,7 @@ export const DEFAULT_FORM: PosterForm = {
   includeRoadMinorLow: true,
   includeRoadOutline: true,
   includeCycleways: false,
+  includeCountryBorders: false,
   showMarkers: true,
   showRoutes: true,
 };
@@ -294,6 +295,7 @@ export function PosterProvider({ children }: { children: ReactNode }) {
         includeRoadMinorLow: state.form.includeRoadMinorLow,
         includeRoadOutline: state.form.includeRoadOutline,
         includeCycleways: state.form.includeCycleways,
+        includeCountryBorders: state.form.includeCountryBorders,
         distanceMeters: Number(state.form.distance),
       }),
     [
@@ -309,6 +311,7 @@ export function PosterProvider({ children }: { children: ReactNode }) {
       state.form.includeRoadMinorLow,
       state.form.includeRoadOutline,
       state.form.includeCycleways,
+      state.form.includeCountryBorders,
       state.form.distance,
     ],
   );

--- a/src/features/poster/ui/SettingsPanel.tsx
+++ b/src/features/poster/ui/SettingsPanel.tsx
@@ -267,6 +267,8 @@ export default function SettingsPanel({
                 minPosterCm={MIN_POSTER_CM}
                 maxPosterCm={MAX_POSTER_CM}
                 onNumericFieldBlur={handleNumericFieldBlur}
+                hasSelectedLocation={Boolean(state.selectedLocation)}
+                boundaryStatus={state.locationBoundaryStatus}
               />
             ) : null}
           </div>

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -218,6 +218,21 @@ label {
   gap: 12px;
 }
 
+.toggle-field--disabled {
+  opacity: 0.5;
+}
+
+.toggle-field--disabled .theme-switch input {
+  cursor: not-allowed;
+}
+
+.layers-section__hint {
+  margin: -4px 0 10px;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  color: #9fbcd0;
+}
+
 .theme-switch {
   position: relative;
   display: inline-flex;


### PR DESCRIPTION
## Summary

Four map and export issues, each as its own commit:

- **#135** — cycle ways layer toggle
- **#140** — country borders layer toggle
- **#146** — clip poster layers to the selected city/country boundary
- **#84** — SVG export writes real vector geometry instead of embedded PNGs

**Please read the overlap note under Notes before reviewing** — #135 and #140 are already covered by open PRs from other contributors.

### #135 — cycle ways

OpenMapTiles files dedicated cycle infrastructure under `class=path` with `subclass=cycleway`, so the layer keys off `subclass`. It is deliberately **independent of the roads toggle**: @afranke's comment on the issue asked for cycle ways *without* roads, which a roads-gated layer would not deliver.

### #140 — country borders

`boundary` source-layer, `admin_level <= 2`, drawn dashed above the map stack. Maritime borders are excluded — they run far offshore and read as noise at poster framing. `to-number` guards the filter against tiles that encode `maritime` as a boolean rather than 0/1. The colour is derived through the existing `blendHex(land, text)` idiom, so no theme palette entries were added.

### #146 — clip to location boundary

MapLibre cannot clip vector layers to an arbitrary polygon. The administrative outline is therefore inverted into a world-sized mask polygon and drawn on top of the map stack in the land colour. This covers every current *and future* map layer without per-layer filters, and carries into PNG, PDF and SVG export for free, since all three rebuild from the live style.

Outlines come from Nominatim's `lookup` endpoint. `polygon_threshold` is always sent, because it has to be — measured payloads:

| Place | Unsimplified | At poster fidelity |
|---|---|---|
| Germany | 3.7 MB | ~20 KB |
| Hamburg | 85 KB | ~31 KB |
| Paris | 23 KB | ~4.7 KB |

`distance` is the map half-width, so a 300 DPI poster renders roughly `distance / 1200` metres per pixel; the tolerance divides by 600 to target about two exported pixels of error. Tolerances snap to a doubling scale, which collapses the entire distance slider into **five cache buckets** rather than one request per pixel of slider travel. Outlines above 20 000 positions are used but not persisted, so a single large boundary cannot take over the localStorage quota shared with the geocoding caches.

### #84 — vector SVG export

The exporter previously toggled one style layer visible at a time, snapshotted the WebGL canvas, and base64-embedded each PNG into a `<g>`. The layer *structure* was real; the content never was.

Map layers are now redrawn as SVG geometry: source features are read from the export map, projected with the same transform already used for markers, and written as paths carrying the layer's resolved colour, width, dash pattern and opacity. Layer grouping is unchanged.

Two decisions worth flagging:

- **Opacity is applied to the group, not to each path.** `querySourceFeatures` returns a feature once per tile it touches, so buffered overlap would double-draw. Per-path opacity darkens tile seams; `<g opacity>` composites the layer as a unit and the artifact disappears.
- **If the style yields no queryable geometry, the exporter falls back to the previous per-layer raster snapshots.** Output is never blank.

## Branch

- [x] I have read the [contributing guidelines](./CONTRIBUTING.md)
- [x] This branch was created from `dev` and this PR targets `dev`

## CLA

- [x] I have read and agree to the [Contributor License Agreement](./CLA.md)

## Implementation

- [x] The implementation matches the requested behavior and UX
- [x] I followed the project architecture and reviewed any AI-assisted code before submitting
- [x] I avoided hard-coded values where constants, configuration, or reusable abstractions are more appropriate

## Validation

- [x] I ran `bun install` and `bun run build`
- [x] I tested the change locally

## UI Changes

- [x] No UI changes
- [x] UI screenshots or demo attached

| Cycle ways, roads **off** | Cycle ways, roads **on** |
|---|---|
| <img width="1919" height="911" alt="image" src="https://github.com/user-attachments/assets/2c5b84a7-f675-494f-b22e-135bf4943430" /> | <img width="1916" height="906" alt="image" src="https://github.com/user-attachments/assets/011c4ed7-3bbe-434c-8aca-da17a9ca4fcd" /> |

Paris. The left shot is the point of #135: the cycle network stands on its own because the layer is not gated on the roads toggle.

| Country borders | Clipped to the selected country |
|---|---|
| <img width="1919" height="912" alt="image" src="https://github.com/user-attachments/assets/73b4246c-99a8-466f-ac79-816ed160c16b" /> | <img width="1919" height="909" alt="image" src="https://github.com/user-attachments/assets/e5eb7f49-173f-400c-88fb-0e3e7fccef2b" /> |

Pakistan. The right shot is #146 at country scale — roads, water and every other layer stop at the national outline, with the surrounding region painted flat in the land colour.

## Notes

### Overlap with existing PRs — please read first

#135 and #140 already have open PRs from other contributors: **#138** (@thomaslrg, cycle ways + ski resorts) and **#142** (@Rutwik1801, country borders). I would rather flag this than have you discover it in review.

If you prefer their implementations, the first two commits here (`cycle ways`, `country borders`) can be dropped and the remaining two features rebase cleanly — they touch different files apart from four adjacent additions in `maplibreStyle.ts`, `LayersSection.tsx`, `posterReducer.ts` and `PosterContext.tsx`. The one behavioural difference worth comparing is that my cycle ways layer is independent of the roads toggle.

Also worth noting: the saved-themes and settings-panel half of #142 has already landed on `dev` (`3c92727`, `fa61b4c`) — only its borders layer is still outstanding.

### Verification

Cycle ways, country borders and the boundary clip are confirmed in the running app (screenshots above). The SVG export's vector output has been verified programmatically against the real generated style but **not yet opened in a vector editor** — if a reviewer finds the geometry does not behave as described, say so and I will correct it rather than defend it.

No new dependencies. All network access goes through the existing `IHttp` adapter with timeouts and localStorage caching; boundary requests only fire on explicit opt-in. No `import.meta.env` reads outside `core/config.ts`.

- Style output validated against `@maplibre/maplibre-gl-style-spec`: **0 errors across all 18 bundled themes × 5 feature combinations**, with and without the mask.
- Tile schema confirmed against the live OpenFreeMap TileJSON rather than assumed — `boundary` exposes `admin_level`/`maritime`, `transportation` exposes `subclass`/`bicycle`.
- Nominatim payloads measured live at several simplification tolerances (table above).
- Vector export driven against the real generated style: every paint expression on every layer resolves at every zoom; interpolation checked against hand-computed values including out-of-range clamping; poster centre projects exactly to canvas centre; stroke width scales exactly; malformed geometry (null, Point, `NaN`, single-position lines) produces no `NaN`/`undefined` in output; hidden and maxzoom-excluded layers are omitted.

### Known limitations

- The boundary mask **hides** out-of-boundary data, it does not stop tiles being fetched. The "saves resources" hope in #146 is not met — filtering at tile level needs geometry operations MapLibre does not expose.
- Interior rings (enclaves, lakes) are dropped. Nested rings are not representable in a single mask polygon and are negligible at poster scale.
- The clip toggle stays disabled until a location is picked from search, since typed coordinates have no OSM element to look up.
- Marker, route and text overlays remain rasterised in SVG. They are canvas renderers, and poster text depends on a webfont an SVG cannot carry — `<text>` would silently substitute a fallback font in Illustrator, which is arguably worse than a faithful raster.
- Vector SVGs of dense cities will be large, broadly comparable to today's embedded PNGs rather than obviously smaller.
- `dev` currently has **3 pre-existing `tsc --noEmit` errors** unrelated to this work (`pngExporter.ts`, `StartupLocationModal.tsx`, `typography.ts`). The count is unchanged on this branch; I did not touch them.

### Follow-up work

Adding a layer currently touches five files, which is why these commits are larger than the features warrant. A declarative layer catalogue driving style generation, form defaults and the toggle UI would reduce each new layer to one entry. I deliberately did **not** do that here — rewriting `PosterForm` / `PosterContext` / `LayersSection` while #127, #138 and #142 are open in those exact files would just hand you conflicts. Happy to open it as an issue and take it once the queue clears.
