### PR TITLE
🐛 fix(docs): restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,4 +158,4 @@ Terraink was inspired by [MapToPoster](https://github.com/originalankur/maptopos
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=yousifamanuel/terraink&type=Date)](https://star-history.com/#yousifamanuel/terraink&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=yousifamanuel/terraink&type=Date)](https://star-history.dera.page/#yousifamanuel/terraink&Date)


### PR DESCRIPTION
The star history chart in the README was broken because the upstream service relies on the GitHub stargazer API, which has been heavily restricted. Without this fix the chart no longer renders.

This switches the chart over to a mirror on star-history.dera.page that uses a different data source and requires no API token, so the chart shows up again.